### PR TITLE
use C++ linker for the extension

### DIFF
--- a/config.m4
+++ b/config.m4
@@ -29,7 +29,7 @@ if test "$PHP_COUCHBASE" != "no"; then
 
   COUCHBASE_FILES="src/php_couchbase.cxx"
 
-  PHP_NEW_EXTENSION(couchbase, ${COUCHBASE_FILES}, $ext_shared)
+  PHP_NEW_EXTENSION(couchbase, ${COUCHBASE_FILES}, $ext_shared,,, cxx)
   PHP_ADD_EXTENSION_DEP(couchbase, json)
   PHP_ADD_BUILD_DIR($ext_builddir/src, 1)
 fi


### PR DESCRIPTION
from Remi Collet:

> 5/ bad linker invoked
> 
> The extension is C++ so should be link using g++, not gcc
> 
> -  PHP_NEW_EXTENSION(couchbase, ${COUCHBASE_FILES}, $ext_shared)
> +  PHP_NEW_EXTENSION(couchbase, ${COUCHBASE_FILES}, $ext_shared,,, cxx)
> 
> This will create issue for people using some specific versions,
> to properly add needed libraries (libstdc++)
> 
> Example when using devtoolset on RHEL/CentOS to have a modern GCC
> (libstdc++ is a static library, only added when g++ is invoked)