### PR TITLE
Fixed skip option string to match wrapper side

### DIFF
--- a/Couchbase/SearchOptions.php
+++ b/Couchbase/SearchOptions.php
@@ -317,7 +317,7 @@ class SearchOptions implements JsonSerializable
         return [
             'timeoutMilliseconds' => $options->timeoutMilliseconds,
             'limit' => $options->limit,
-            'from' => $options->skip,
+            'skip' => $options->skip,
             'explain' => $options->explain,
             'disableScoring' => $options->disableScoring,
             'fields' => $options->fields,


### PR DESCRIPTION
Fixed bug which stopped the 'skip' search option from working as intended [PCBC-889](https://issues.couchbase.com/browse/PCBC-889)