### PR TITLE
Fix missing header for GCC 13

### DIFF
--- a/src/wrapper/core_error_info.hxx
+++ b/src/wrapper/core_error_info.hxx
@@ -23,6 +23,7 @@
 #include <system_error>
 #include <variant>
 #include <vector>
+#include <cstdint>
 
 namespace couchbase::php
 {


### PR DESCRIPTION
This is not enough, the same header needs to be added in a lot of files in deps:

- src/deps/couchbase-cxx-client/core/error_context/analytics.hxx
- src/deps/couchbase-cxx-client/core/error_context/http.hxx
- src/deps/couchbase-cxx-client/core/error_context/query.hxx
- src/deps/couchbase-cxx-client/core/error_context/search.hxx
- src/deps/couchbase-cxx-client/core/error_context/view.hxx
- src/deps/couchbase-cxx-client/core/impl/subdoc/lookup_in_macro.cxx
- src/deps/couchbase-cxx-client/core/impl/subdoc/mutate_in_macro.cxx
- src/deps/couchbase-cxx-client/core/operations/management/analytics_problem.hxx
- src/deps/couchbase-cxx-client/core/operations/management/eventing_problem.hxx
- src/deps/couchbase-cxx-client/core/platform/base64.cc
- src/deps/couchbase-cxx-client/core/protocol/client_opcode.hxx
- src/deps/couchbase-cxx-client/core/protocol/cmd_info.hxx
- src/deps/couchbase-cxx-client/core/utils/crc32.hxx
- src/deps/couchbase-cxx-client/core/utils/json_streaming_lexer.hxx
- src/deps/couchbase-cxx-client/core/utils/url_codec.cxx
- src/deps/couchbase-cxx-client/couchbase/query_index_manager.hxx