### PR TITLE
update core to 1.0.0-beta.5

### DIFF
--- a/Couchbase/QueryOptions.php
+++ b/Couchbase/QueryOptions.php
@@ -43,8 +43,7 @@ class QueryOptions
     private ?string $clientContextId = null;
     private ?bool $metrics = null;
     private ?bool $preserveExpiry = null;
-    private ?string $scopeName = null;
-    private ?string $scopeQualifier = null;
+    private ?string $queryContext = null;
     private Transcoder $transcoder;
 
     /**
@@ -332,7 +331,6 @@ class QueryOptions
             'Method ' . __METHOD__ . ' is deprecated, use scope level query()',
             E_USER_DEPRECATED
         );
-        $this->scopeName = $name;
         return $this;
     }
 
@@ -353,7 +351,7 @@ class QueryOptions
             'Method ' . __METHOD__ . ' is deprecated, use scope level query()',
             E_USER_DEPRECATED
         );
-        $this->scopeQualifier = $qualifier;
+        $this->queryContext = $qualifier;
         return $this;
     }
 
@@ -403,10 +401,14 @@ class QueryOptions
 
     public static function export(?QueryOptions $options, string $scopeName = null, string $bucketName = null): array
     {
+        $defaultQueryContext = null;
+        if ($scopeName != null && $bucketName != null) {
+            $defaultQueryContext = sprintf("default:`%s`.`%s`", $bucketName, $scopeName);
+        }
+
         if ($options == null) {
             return [
-                'scopeName' => $scopeName,
-                'bucketName' => $bucketName,
+                'queryContext' => $defaultQueryContext
             ];
         }
 
@@ -427,9 +429,6 @@ class QueryOptions
             foreach ($options->raw as $key => $param) {
                 $raw[$key] = json_encode($param);
             }
-        }
-        if ($scopeName == null && $options->scopeName != null) {
-            $scopeName = $options->scopeName;
         }
 
         return [
@@ -452,9 +451,7 @@ class QueryOptions
             'clientContextId' => $options->clientContextId,
             'metrics' => $options->metrics,
             'preserveExpiry' => $options->preserveExpiry,
-            'scopeName' => $scopeName,
-            'bucketName' => $bucketName,
-            'scopeQualifier' => $options->scopeQualifier,
+            'queryContext' => $options->queryContext == null ? $defaultQueryContext : $options->queryContext,
         ];
     }
 }

--- a/package.xml
+++ b/package.xml
@@ -13,7 +13,7 @@
         <email>sergey@couchbase.com</email>
         <active>yes</active>
     </lead>
-    <date>2023-02-16</date>
+    <date>2023-02-19</date>
     <version>
         <release>4.1.0</release>
         <api>4.0.0</api>
@@ -425,16 +425,20 @@
                                 <file role="src" name="bootstrap_state_listener.hxx"/>
                                 <file role="src" name="build_deferred_query_indexes.cxx"/>
                                 <file role="src" name="cluster.cxx"/>
+                                <file role="src" name="collection_query_index_manager.cxx"/>
                                 <file role="src" name="common_error_category.cxx"/>
                                 <file role="src" name="configuration_profiles_registry.cxx"/>
+                                <file role="src" name="create_query_index.cxx"/>
                                 <file role="src" name="decrement.cxx"/>
                                 <file role="src" name="dns_srv_tracker.cxx"/>
                                 <file role="src" name="dns_srv_tracker.hxx"/>
+                                <file role="src" name="drop_query_index.cxx"/>
                                 <file role="src" name="exists.cxx"/>
                                 <file role="src" name="expiry.cxx"/>
                                 <file role="src" name="fail_fast_retry_strategy.cxx"/>
                                 <file role="src" name="field_level_encryption_error_category.cxx"/>
                                 <file role="src" name="get.cxx"/>
+                                <file role="src" name="get_all_query_indexes.cxx"/>
                                 <file role="src" name="get_all_replicas.cxx"/>
                                 <file role="src" name="get_all_replicas.hxx"/>
                                 <file role="src" name="get_and_lock.cxx"/>
@@ -469,6 +473,7 @@
                                 <file role="src" name="unlock.cxx"/>
                                 <file role="src" name="upsert.cxx"/>
                                 <file role="src" name="view_error_category.cxx"/>
+                                <file role="src" name="watch_query_indexes.cxx"/>
                                 <file role="src" name="with_legacy_durability.hxx"/>
                             </dir>
                             <dir name="io">
@@ -529,7 +534,6 @@
                                 <file role="src" name="eventing_function_json.hxx"/>
                                 <file role="src" name="eventing_status.hxx"/>
                                 <file role="src" name="eventing_status_json.hxx"/>
-                                <file role="src" name="query_index.hxx"/>
                                 <file role="src" name="rbac.hxx"/>
                                 <file role="src" name="rbac_fmt.hxx"/>
                                 <file role="src" name="rbac_json.hxx"/>
@@ -1005,6 +1009,7 @@
                                 <file role="src" name="json_stream_control.hxx"/>
                                 <file role="src" name="json_streaming_lexer.cxx"/>
                                 <file role="src" name="json_streaming_lexer.hxx"/>
+                                <file role="src" name="keyspace.hxx"/>
                                 <file role="src" name="movable_function.hxx"/>
                                 <file role="src" name="mutation_token.cxx"/>
                                 <file role="src" name="mutation_token.hxx"/>
@@ -1079,6 +1084,7 @@
                             <file role="src" name="ping_collector.hxx"/>
                             <file role="src" name="ping_options.hxx"/>
                             <file role="src" name="ping_reporter.hxx"/>
+                            <file role="src" name="query_context.hxx"/>
                             <file role="src" name="range_scan_options.cxx"/>
                             <file role="src" name="range_scan_options.hxx"/>
                             <file role="src" name="range_scan_orchestrator.cxx"/>
@@ -1133,6 +1139,9 @@
                                 <file role="src" name="retry_reason.hxx"/>
                                 <file role="src" name="tls_verify_mode.hxx"/>
                             </dir>
+                            <dir name="management">
+                                <file role="src" name="query_index.hxx"/>
+                            </dir>
                             <dir name="metrics">
                                 <file role="src" name="meter.hxx"/>
                                 <file role="src" name="otel_meter.hxx"/>
@@ -1185,14 +1194,19 @@
                             <file role="src" name="cluster.hxx"/>
                             <file role="src" name="cluster_options.hxx"/>
                             <file role="src" name="collection.hxx"/>
+                            <file role="src" name="collection_query_index_manager.hxx"/>
                             <file role="src" name="common_durability_options.hxx"/>
                             <file role="src" name="common_options.hxx"/>
                             <file role="src" name="compression_options.hxx"/>
                             <file role="src" name="configuration_profile.hxx"/>
                             <file role="src" name="configuration_profiles_registry.hxx"/>
                             <file role="src" name="counter_result.hxx"/>
+                            <file role="src" name="create_primary_query_index_options.hxx"/>
+                            <file role="src" name="create_query_index_options.hxx"/>
                             <file role="src" name="decrement_options.hxx"/>
                             <file role="src" name="dns_options.hxx"/>
+                            <file role="src" name="drop_primary_query_index_options.hxx"/>
+                            <file role="src" name="drop_query_index_options.hxx"/>
                             <file role="src" name="durability_level.hxx"/>
                             <file role="src" name="error_codes.hxx"/>
                             <file role="src" name="error_context.hxx"/>
@@ -1200,6 +1214,7 @@
                             <file role="src" name="exists_result.hxx"/>
                             <file role="src" name="expiry.hxx"/>
                             <file role="src" name="fail_fast_retry_strategy.hxx"/>
+                            <file role="src" name="get_all_query_indexes_options.hxx"/>
                             <file role="src" name="get_all_replicas_options.hxx"/>
                             <file role="src" name="get_and_lock_options.hxx"/>
                             <file role="src" name="get_and_touch_options.hxx"/>
@@ -1262,6 +1277,7 @@
                             <file role="src" name="unlock_options.hxx"/>
                             <file role="src" name="upsert_options.hxx"/>
                             <file role="src" name="wan_development_configuration_profile.hxx"/>
+                            <file role="src" name="watch_query_indexes_options.hxx"/>
                         </dir>
                         <dir name="third_party">
                             <dir name="asio">

--- a/src/wrapper/conversion_utilities.cxx
+++ b/src/wrapper/conversion_utilities.cxx
@@ -421,10 +421,7 @@ zval_to_query_request(const zend_string* statement, const zval* options)
     if (auto e = cb_assign_boolean(request.preserve_expiry, options, "preserveExpiry"); e.ec) {
         return { {}, e };
     }
-    if (auto e = cb_assign_string(request.scope_name, options, "scopeName"); e.ec) {
-        return { {}, e };
-    }
-    if (auto e = cb_assign_string(request.bucket_name, options, "bucketName"); e.ec) {
+    if (auto e = cb_assign_string(request.query_context, options, "queryContext"); e.ec) {
         return { {}, e };
     }
     return { request, {} };

--- a/src/wrapper/transaction_context_resource.cxx
+++ b/src/wrapper/transaction_context_resource.cxx
@@ -132,8 +132,9 @@ build_error_context(const core::transactions::transaction_exception& e)
     out.type = failure_type_to_string(e.type());
     out.cause = external_exception_to_string(e.cause());
     transactions_error_context::transaction_result res;
-    res.transaction_id = e.get_transaction_result().transaction_id;
-    res.unstaging_complete = e.get_transaction_result().unstaging_complete;
+    auto [_, core_res] = e.get_transaction_result();
+    res.transaction_id = core_res.transaction_id;
+    res.unstaging_complete = core_res.unstaging_complete;
     out.result = res;
     return out;
 }


### PR DESCRIPTION
This one update core to pickup GCC-13 fixes. Also it happened that query_context changes has been merged to the core already. While it touches related places in PHP sources, it does not implement any of planned changes to query management API, which will come later.