### PR TITLE
relax requirement of the test

### DIFF
--- a/tests/QueryTest.php
+++ b/tests/QueryTest.php
@@ -111,8 +111,8 @@ class QueryTest extends Helpers\CouchbaseTestCase
                     ->namedParameters(["key" => $key]);
                 $this->cluster->query("SELECT * FROM $nameSpace USE KEYS $key", $options);
             },
-            '\Couchbase\Exception\ParsingFailureException',
-            8,
+            null,
+            null,
             '/Ambiguous reference to field/'
         );
     }


### PR DESCRIPTION
in fact query engine started returning different error code for this kind of user error, but in particular case it does not matter, and matching for error text is enough here.

Old error code was `(3000, IKey: "parse.syntax_error")`, mapped to `ParsingFailureException`, while new code is `(3080, IKey: "formalize.ambiguous_reference")`