### PR TITLE
update core

### DIFF
--- a/bin/build
+++ b/bin/build
@@ -94,9 +94,9 @@ Dir.chdir(PROJECT_ROOT) do
 end
 
 COUCHBASE_EXT = "#{PROJECT_ROOT}/modules/couchbase.#{RbConfig::CONFIG["DLEXT"]}"
-unless File.exists?(COUCHBASE_EXT)
+unless File.exist?(COUCHBASE_EXT)
   alt_filename = "#{PROJECT_ROOT}/modules/couchbase.so"
-  if File.exists?(alt_filename)
+  if File.exist?(alt_filename)
     COUCHBASE_EXT = alt_filename
   end
 end

--- a/bin/console
+++ b/bin/console
@@ -35,9 +35,9 @@ DEFAULT_PHP_PREFIX =
 CB_PHP_PREFIX = ENV.fetch("CB_PHP_PREFIX", DEFAULT_PHP_PREFIX)
 
 COUCHBASE_EXT="#{PROJECT_ROOT}/modules/couchbase.#{RbConfig::CONFIG["DLEXT"]}"
-unless File.exists?(COUCHBASE_EXT)
+unless File.exist?(COUCHBASE_EXT)
   alt_filename = "#{PROJECT_ROOT}/modules/couchbase.so"
-  if File.exists?(alt_filename)
+  if File.exist?(alt_filename)
     COUCHBASE_EXT = alt_filename
   end
 end

--- a/bin/test
+++ b/bin/test
@@ -82,9 +82,9 @@ unless File.file?(php_unit_phar)
 end
 
 couchbase_ext = "#{project_root}/modules/couchbase.#{RbConfig::CONFIG["DLEXT"]}"
-unless File.exists?(couchbase_ext)
+unless File.exist?(couchbase_ext)
   alt_filename = "#{project_root}/modules/couchbase.so"
-  if File.exists?(alt_filename)
+  if File.exist?(alt_filename)
     couchbase_ext = alt_filename
   end
 end

--- a/package.xml
+++ b/package.xml
@@ -13,7 +13,7 @@
         <email>sergey@couchbase.com</email>
         <active>yes</active>
     </lead>
-    <date>2023-04-13</date>
+    <date>2023-05-12</date>
     <version>
         <release>4.1.3</release>
         <api>4.0.0</api>
@@ -980,9 +980,11 @@
                                 <file role="src" name="attempt_context.hxx"/>
                                 <file role="src" name="attempt_context_impl.cxx"/>
                                 <file role="src" name="attempt_context_impl.hxx"/>
+                                <file role="src" name="attempt_context_testing_hooks.cxx"/>
                                 <file role="src" name="attempt_context_testing_hooks.hxx"/>
                                 <file role="src" name="attempt_state.hxx"/>
                                 <file role="src" name="binary.cxx"/>
+                                <file role="src" name="cleanup_testing_hooks.cxx"/>
                                 <file role="src" name="cleanup_testing_hooks.hxx"/>
                                 <file role="src" name="document_metadata.hxx"/>
                                 <file role="src" name="durability_level.hxx"/>
@@ -1059,6 +1061,7 @@
                             <file role="src" name="cluster_agent_config.hxx"/>
                             <file role="src" name="cluster_options.cxx"/>
                             <file role="src" name="cluster_options.hxx"/>
+                            <file role="src" name="cluster_options_fwd.hxx"/>
                             <file role="src" name="cluster_state.hxx"/>
                             <file role="src" name="collection_id_cache_entry.hxx"/>
                             <file role="src" name="collections_component.cxx"/>
@@ -1066,8 +1069,9 @@
                             <file role="src" name="collections_component_unit_test_api.hxx"/>
                             <file role="src" name="collections_options.hxx"/>
                             <file role="src" name="config_listener.hxx"/>
-                            <file role="src" name="config_profile.cxx"/>
                             <file role="src" name="config_profile.hxx"/>
+                            <file role="src" name="config_profiles.cxx"/>
+                            <file role="src" name="config_profiles.hxx"/>
                             <file role="src" name="core_sdk_shim.cxx"/>
                             <file role="src" name="core_sdk_shim.hxx"/>
                             <file role="src" name="crud_component.cxx"/>
@@ -1090,6 +1094,7 @@
                             <file role="src" name="json_string.hxx"/>
                             <file role="src" name="key_value_config.cxx"/>
                             <file role="src" name="key_value_config.hxx"/>
+                            <file role="src" name="mozilla_ca_bundle.hxx"/>
                             <file role="src" name="n1ql_query_options.cxx"/>
                             <file role="src" name="n1ql_query_options.hxx"/>
                             <file role="src" name="operation_map.hxx"/>
@@ -1099,6 +1104,7 @@
                             <file role="src" name="ping_collector.hxx"/>
                             <file role="src" name="ping_options.hxx"/>
                             <file role="src" name="ping_reporter.hxx"/>
+                            <file role="src" name="public_fwd.hxx"/>
                             <file role="src" name="query_context.hxx"/>
                             <file role="src" name="range_scan_options.cxx"/>
                             <file role="src" name="range_scan_options.hxx"/>
@@ -1123,6 +1129,7 @@
                             <file role="src" name="stats_options.hxx"/>
                             <file role="src" name="subdoc_options.hxx"/>
                             <file role="src" name="timeout_defaults.hxx"/>
+                            <file role="src" name="tls_verify_mode.hxx"/>
                             <file role="src" name="transactions.hxx"/>
                             <file role="src" name="view_on_error.hxx"/>
                             <file role="src" name="view_query_options.cxx"/>
@@ -1184,6 +1191,7 @@
                             </dir>
                             <dir name="tracing">
                                 <file role="src" name="otel_tracer.hxx"/>
+                                <file role="src" name="request_span.hxx"/>
                                 <file role="src" name="request_tracer.hxx"/>
                             </dir>
                             <dir name="transactions">

--- a/src/wrapper/version.cxx
+++ b/src/wrapper/version.cxx
@@ -33,9 +33,10 @@ core_version(zval* return_value)
     add_assoc_string(return_value, "cxx_client_revision", COUCHBASE_CXX_CLIENT_GIT_REVISION);
 
     for (const auto& [name, value] : core::meta::sdk_build_info()) {
-        if (name == "version_major" || name == "version_minor" || name == "version_patch" || name == "version_build") {
+        if (name == "version_major" || name == "version_minor" || name == "version_patch" || name == "version_build" ||
+            name == "__cplusplus" || name == "_MSC_VER" || name == "mozilla_ca_bundle_size") {
             add_assoc_long_ex(return_value, name.c_str(), name.size(), std::stoi(value));
-        } else if (name == "snapshot" || name == "static_stdlib" || name == "static_openssl") {
+        } else if (name == "snapshot" || name == "static_stdlib" || name == "static_openssl" || name == "mozilla_ca_bundle_embedded") {
             add_assoc_bool_ex(return_value, name.c_str(), name.size(), value == "true");
         } else {
             add_assoc_stringl_ex(return_value, name.c_str(), name.size(), value.c_str(), value.size());


### PR DESCRIPTION
Notable changes:

* CXXCBC-327: bundle Mozilla certificates with the library (#405)
* CXXCBC-324: check port and network name on session restart (#401)
* CXXCBC-323: parse bootstrap_timeout and resolve_timeout in connection string (#400)
* introduce option dump_configuration for debugging (#398)