### PR TITLE
PCBC-964: wait until the core connection is closed

### DIFF
--- a/src/php_couchbase.cxx
+++ b/src/php_couchbase.cxx
@@ -184,7 +184,7 @@ couchbase_throw_exception(const couchbase::php::core_error_info& error_info)
 
 PHP_MSHUTDOWN_FUNCTION(couchbase)
 {
-    couchbase::php::flush_logger();
+    couchbase::php::shutdown_logger();
 
     (void)type;
     (void)module_number;

--- a/src/wrapper/connection_handle.cxx
+++ b/src/wrapper/connection_handle.cxx
@@ -585,6 +585,11 @@ connection_handle::connection_handle(std::string connection_string,
     impl_->start();
 }
 
+connection_handle::~connection_handle()
+{
+    impl_->stop();
+}
+
 COUCHBASE_API
 core_error_info
 connection_handle::open()

--- a/src/wrapper/connection_handle.hxx
+++ b/src/wrapper/connection_handle.hxx
@@ -45,6 +45,9 @@ class connection_handle
                       std::chrono::system_clock::time_point idle_expiry);
 
     COUCHBASE_API
+    ~connection_handle();
+
+    COUCHBASE_API
     std::shared_ptr<couchbase::core::cluster> cluster() const;
 
     COUCHBASE_API

--- a/src/wrapper/logger.cxx
+++ b/src/wrapper/logger.cxx
@@ -120,6 +120,15 @@ flush_logger()
 
 COUCHBASE_API
 void
+shutdown_logger()
+{
+    flush_logger();
+    couchbase::core::logger::shutdown();
+}
+
+
+COUCHBASE_API
+void
 initialize_logger()
 {
     auto spd_log_level = spdlog::level::off;

--- a/src/wrapper/logger.hxx
+++ b/src/wrapper/logger.hxx
@@ -40,4 +40,8 @@ initialize_logger();
 COUCHBASE_API
 void
 flush_logger();
+
+COUCHBASE_API
+void
+shutdown_logger();
 } // namespace couchbase::php


### PR DESCRIPTION
* the wrapper should wait until the core connection is closed in order to ensure that the in-flight operations will not use any invalid resources

* shutdown logger when the module is being unloaded