### PR TITLE
add missing use statement in class DecrementOptions

### DIFF
--- a/Couchbase/DecrementOptions.php
+++ b/Couchbase/DecrementOptions.php
@@ -21,6 +21,7 @@ declare(strict_types=1);
 namespace Couchbase;
 
 use Couchbase\Utilities\Deprecations;
+use DateTimeInterface;
 
 class DecrementOptions
 {


### PR DESCRIPTION
In v4.1.6, the following code piece will fail when executed:

```php
<?php

// ...
$options = new Couchbase\DecrementOptions();
$options->initial(1);
$options->expiry((new DateTimeImmutable())->modify('+5 seconds'));

$collection->binary()->decrement($key, $options);
?>
```

The error message looks like the following:

> Warning: Object of class DateTimeImmutable could not be converted to int in vendor/couchbase/couchbase/Couchbase/DecrementOptions.php on line 123