### PR TITLE
PCBC-979 Add static helpers to SearchQuery types

### DIFF
--- a/Couchbase/BooleanFieldSearchQuery.php
+++ b/Couchbase/BooleanFieldSearchQuery.php
@@ -37,6 +37,19 @@ class BooleanFieldSearchQuery implements JsonSerializable, SearchQuery
     }
 
     /**
+     * Static helper to keep code more readable
+     *
+     * @param bool $value
+     *
+     * @return BooleanFieldSearchQuery
+     * @since 4.1.7
+     */
+    public static function build(bool $value): BooleanFieldSearchQuery
+    {
+        return new BooleanFieldSearchQuery($value);
+    }
+
+    /**
      * Sets the boost for this query.
      *
      * @param float $boost the boost value to use.

--- a/Couchbase/BooleanSearchQuery.php
+++ b/Couchbase/BooleanSearchQuery.php
@@ -40,6 +40,17 @@ class BooleanSearchQuery implements JsonSerializable, SearchQuery
     }
 
     /**
+     * Static helper to keep code more readable
+     *
+     * @return BooleanSearchQuery
+     * @since 4.1.7
+     */
+    public static function build(): BooleanSearchQuery
+    {
+        return new BooleanSearchQuery();
+    }
+
+    /**
      * Sets the boost for this query.
      *
      * @param float $boost the boost value to use.

--- a/Couchbase/ConjunctionSearchQuery.php
+++ b/Couchbase/ConjunctionSearchQuery.php
@@ -37,6 +37,19 @@ class ConjunctionSearchQuery implements JsonSerializable, SearchQuery
     }
 
     /**
+     * Static helper to keep code more readable
+     *
+     * @param array $queries
+     *
+     * @return ConjunctionSearchQuery
+     * @since 4.1.7
+     */
+    public static function build(array $queries): ConjunctionSearchQuery
+    {
+        return new ConjunctionSearchQuery($queries);
+    }
+
+    /**
      * Sets the boost for this query.
      *
      * @param float $boost the boost value to use.

--- a/Couchbase/DateRangeSearchQuery.php
+++ b/Couchbase/DateRangeSearchQuery.php
@@ -38,6 +38,17 @@ class DateRangeSearchQuery implements JsonSerializable, SearchQuery
     private ?string $datetimeParser = null;
 
     /**
+     * Static helper to keep code more readable
+     *
+     * @return DateRangeSearchQuery
+     * @since 4.1.7
+     */
+    public static function build(): DateRangeSearchQuery
+    {
+        return new DateRangeSearchQuery();
+    }
+
+    /**
      * Sets the boost for this query.
      *
      * @param float $boost the boost value to use.

--- a/Couchbase/DisjunctionSearchQuery.php
+++ b/Couchbase/DisjunctionSearchQuery.php
@@ -42,6 +42,19 @@ class DisjunctionSearchQuery implements JsonSerializable, SearchQuery
     }
 
     /**
+     * Static helper to keep code more readable
+     *
+     * @param array $queries
+     *
+     * @return DisjunctionSearchQuery
+     * @since 4.1.7
+     */
+    public static function build(array $queries): DisjunctionSearchQuery
+    {
+        return new DisjunctionSearchQuery($queries);
+    }
+
+    /**
      * Sets the boost for this query.
      *
      * @param float $boost the boost value to use.

--- a/Couchbase/DocIdSearchQuery.php
+++ b/Couchbase/DocIdSearchQuery.php
@@ -37,6 +37,17 @@ class DocIdSearchQuery implements SearchQuery
     }
 
     /**
+     * Static helper to keep code more readable
+     *
+     * @return DocIdSearchQuery
+     * @since 4.1.7
+     */
+    public static function build(): DocIdSearchQuery
+    {
+        return new DocIdSearchQuery();
+    }
+
+    /**
      * Sets the boost for this query.
      *
      * @param float $boost the boost value to use.

--- a/Couchbase/GeoBoundingBoxSearchQuery.php
+++ b/Couchbase/GeoBoundingBoxSearchQuery.php
@@ -51,6 +51,22 @@ class GeoBoundingBoxSearchQuery implements JsonSerializable, SearchQuery
     }
 
     /**
+     * Static helper to keep code more readable
+     *
+     * @param float $topLeftLongitude
+     * @param float $topLeftLatitude
+     * @param float $bottomRightLongitude
+     * @param float $bottomRightLatitude
+     *
+     * @return GeoBoundingBoxSearchQuery
+     * @since 4.1.7
+     */
+    public static function build(float $topLeftLongitude, float $topLeftLatitude, float $bottomRightLongitude, float $bottomRightLatitude): GeoBoundingBoxSearchQuery
+    {
+        return new GeoBoundingBoxSearchQuery($topLeftLongitude, $topLeftLatitude, $bottomRightLongitude, $bottomRightLatitude);
+    }
+
+    /**
      * Sets the boost for this query.
      *
      * @param float $boost the boost value to use.

--- a/Couchbase/GeoDistanceSearchQuery.php
+++ b/Couchbase/GeoDistanceSearchQuery.php
@@ -50,6 +50,21 @@ class GeoDistanceSearchQuery implements JsonSerializable, SearchQuery
     }
 
     /**
+     * Static helper to keep code more readable
+     *
+     * @param float $longitude
+     * @param float $latitude
+     * @param string|null $distance
+     *
+     * @return GeoDistanceSearchQuery
+     * @since 4.1.7
+     */
+    public static function build(float $longitude, float $latitude, string $distance = null): GeoDistanceSearchQuery
+    {
+        return new GeoDistanceSearchQuery($longitude, $latitude, $distance);
+    }
+
+    /**
      * Sets the boost for this query.
      *
      * @param float $boost the boost value to use.

--- a/Couchbase/MatchAllSearchQuery.php
+++ b/Couchbase/MatchAllSearchQuery.php
@@ -30,6 +30,17 @@ class MatchAllSearchQuery implements JsonSerializable, SearchQuery
     private ?float $boost = null;
 
     /**
+     * Static helper to keep code more readable
+     *
+     * @return MatchAllSearchQuery
+     * @since 4.1.7
+     */
+    public static function build(): MatchAllSearchQuery
+    {
+        return new MatchAllSearchQuery();
+    }
+
+    /**
      * Sets the boost for this query.
      *
      * @param float $boost the boost value to use.

--- a/Couchbase/MatchNoneSearchQuery.php
+++ b/Couchbase/MatchNoneSearchQuery.php
@@ -30,6 +30,17 @@ class MatchNoneSearchQuery implements JsonSerializable, SearchQuery
     private ?float $boost = null;
 
     /**
+     * Static helper to keep code more readable
+     *
+     * @return MatchNoneSearchQuery
+     * @since 4.1.7
+     */
+    public static function build(): MatchNoneSearchQuery
+    {
+        return new MatchNoneSearchQuery();
+    }
+
+    /**
      * Sets the boost for this query.
      *
      * @param float $boost the boost value to use.

--- a/Couchbase/MatchPhraseSearchQuery.php
+++ b/Couchbase/MatchPhraseSearchQuery.php
@@ -39,6 +39,19 @@ class MatchPhraseSearchQuery implements JsonSerializable, SearchQuery
     }
 
     /**
+     * Static helper to keep code more readable
+     *
+     * @param string $phrase
+     *
+     * @return MatchPhraseSearchQuery
+     * @since 4.1.7
+     */
+    public static function build(string $phrase): MatchPhraseSearchQuery
+    {
+        return new MatchPhraseSearchQuery($phrase);
+    }
+
+    /**
      * Sets the boost for this query.
      *
      * @param float $boost the boost value to use.

--- a/Couchbase/MatchSearchQuery.php
+++ b/Couchbase/MatchSearchQuery.php
@@ -45,6 +45,19 @@ class MatchSearchQuery implements JsonSerializable, SearchQuery
     }
 
     /**
+     * Static helper to keep code more readable
+     *
+     * @param string $match
+     *
+     * @return MatchSearchQuery
+     * @since 4.1.7
+     */
+    public static function build(string $match): MatchSearchQuery
+    {
+        return new MatchSearchQuery($match);
+    }
+
+    /**
      * Sets the boost for this query.
      *
      * @param float $boost the boost value to use.

--- a/Couchbase/NumericRangeSearchQuery.php
+++ b/Couchbase/NumericRangeSearchQuery.php
@@ -37,6 +37,17 @@ class NumericRangeSearchQuery implements JsonSerializable, SearchQuery
     private ?bool $inclusiveMax = null;
 
     /**
+     * Static helper to keep code more readable
+     *
+     * @return NumericRangeSearchQuery
+     * @since 4.1.7
+     */
+    public static function build(): NumericRangeSearchQuery
+    {
+        return new NumericRangeSearchQuery();
+    }
+
+    /**
      * Sets the boost for this query.
      *
      * @param float $boost the boost value to use.

--- a/Couchbase/PhraseSearchQuery.php
+++ b/Couchbase/PhraseSearchQuery.php
@@ -43,6 +43,19 @@ class PhraseSearchQuery implements JsonSerializable, SearchQuery
     }
 
     /**
+     * Static helper to keep code more readable
+     *
+     * @param string ...$terms
+     *
+     * @return PhraseSearchQuery
+     * @since 4.1.7
+     */
+    public static function build(string ...$terms): PhraseSearchQuery
+    {
+        return new PhraseSearchQuery(...$terms);
+    }
+
+    /**
      * Sets the boost for this query.
      *
      * @param float $boost the boost value to use.

--- a/Couchbase/PrefixSearchQuery.php
+++ b/Couchbase/PrefixSearchQuery.php
@@ -40,6 +40,19 @@ class PrefixSearchQuery implements JsonSerializable, SearchQuery
     }
 
     /**
+     * Static helper to keep code more readable
+     *
+     * @param string $prefix
+     *
+     * @return PrefixSearchQuery
+     * @since 4.1.7
+     */
+    public static function build(string $prefix): PrefixSearchQuery
+    {
+        return new PrefixSearchQuery($prefix);
+    }
+
+    /**
      * Sets the boost for this query.
      *
      * @param float $boost the boost value to use.

--- a/Couchbase/QueryStringSearchQuery.php
+++ b/Couchbase/QueryStringSearchQuery.php
@@ -39,6 +39,19 @@ class QueryStringSearchQuery implements JsonSerializable, SearchQuery
     }
 
     /**
+     * Static helper to keep code more readable
+     *
+     * @param string $queryString
+     *
+     * @return QueryStringSearchQuery
+     * @since 4.1.7
+     */
+    public static function build(string $queryString): QueryStringSearchQuery
+    {
+        return new QueryStringSearchQuery($queryString);
+    }
+
+    /**
      * Sets the boost for this query.
      *
      * @param float $boost the boost value to use.

--- a/Couchbase/RegexpSearchQuery.php
+++ b/Couchbase/RegexpSearchQuery.php
@@ -35,6 +35,19 @@ class RegexpSearchQuery implements SearchQuery
     }
 
     /**
+     * Static helper to keep code more readable
+     *
+     * @param string $regexp
+     *
+     * @return RegexpSearchQuery
+     * @since 4.1.7
+     */
+    public static function build(string $regexp): RegexpSearchQuery
+    {
+        return new RegexpSearchQuery($regexp);
+    }
+
+    /**
      * Sets the boost for this query.
      *
      * @param float $boost the boost value to use.

--- a/Couchbase/SearchRequest.php
+++ b/Couchbase/SearchRequest.php
@@ -49,7 +49,7 @@ class SearchRequest
     }
 
     /**
-     * Static builder to keep code more readable.
+     * Static helper to keep code more readable
      *
      * Use {@link SearchRequest::searchQuery()} or {@link SearchRequest::vectorSearch()} to combine a SearchQuery
      * with a VectorQuery.

--- a/Couchbase/TermRangeSearchQuery.php
+++ b/Couchbase/TermRangeSearchQuery.php
@@ -37,6 +37,17 @@ class TermRangeSearchQuery implements JsonSerializable, SearchQuery
     private ?bool $inclusiveMax = null;
 
     /**
+     * Static helper to keep code more readable
+     *
+     * @return TermRangeSearchQuery
+     * @since 4.1.7
+     */
+    public static function build(): TermRangeSearchQuery
+    {
+        return new TermRangeSearchQuery();
+    }
+
+    /**
      * Sets the boost for this query.
      *
      * @param float $boost the boost value to use.

--- a/Couchbase/TermSearchQuery.php
+++ b/Couchbase/TermSearchQuery.php
@@ -42,6 +42,19 @@ class TermSearchQuery implements JsonSerializable, SearchQuery
     }
 
     /**
+     * Static helper to keep code more readable
+     *
+     * @param string $term
+     *
+     * @return TermSearchQuery
+     * @since 4.1.7
+     */
+    public static function build(string $term): TermSearchQuery
+    {
+        return new TermSearchQuery($term);
+    }
+
+    /**
      * Sets the boost for this query.
      *
      * @param float $boost the boost value to use.

--- a/Couchbase/WildcardSearchQuery.php
+++ b/Couchbase/WildcardSearchQuery.php
@@ -40,6 +40,19 @@ class WildcardSearchQuery implements JsonSerializable, SearchQuery
     }
 
     /**
+     * Static helper to keep code more readable
+     *
+     * @param string $wildcard
+     *
+     * @return WildcardSearchQuery
+     * @since 4.1.7
+     */
+    public static function build(string $wildcard): WildcardSearchQuery
+    {
+        return new WildcardSearchQuery($wildcard);
+    }
+
+    /**
      * Sets the boost for this query.
      *
      * @param float $boost the boost value to use.


### PR DESCRIPTION
Changes:

- Add static helpers to SearchQueries, particularly useful for chaining with cluster/scope.search() API