### PR TITLE
update in test PessimisticLocking

### DIFF
--- a/tests/KeyValueLockingTest.php
+++ b/tests/KeyValueLockingTest.php
@@ -46,9 +46,6 @@ class KeyValueLockingTest extends Helpers\CouchbaseTestCase
         $this->assertNotEquals($lockedCas, $res->cas());
 
         $collection->unlock($id, $lockedCas);
-
-        $res = $collection->get($id);
-        $this->assertEquals($lockedCas, $res->cas());
     }
 
     public function testUnlockingUnlockedDocumentThrowsDocNotLocked()


### PR DESCRIPTION
update in test PessimisticLocking, check if CAS value before document locked is same as CAS value after the document gets unlocked