### PR TITLE
PCBC-969: move grpc dependencies to suggests section

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -46,6 +46,7 @@
 /mkinstalldirs
 /modules/
 /package.xml
+/composer.phar
 /phpunit.result.cache
 /run-tests.php
 /src/.idea/

--- a/Couchbase/Cluster.php
+++ b/Couchbase/Cluster.php
@@ -85,8 +85,17 @@ class Cluster implements ClusterInterface
         return ClusterRegistry::connect($connectionString, $options);
     }
 
+    /**
+     * @throws InvalidArgumentException if runtime dependencies are missing ("protobuf" and "grpc" modules)
+     */
     private static function enableProtostellar(): void
     {
+        if (!extension_loaded("protobuf")) {
+            throw new InvalidArgumentException("couchbase2:// protocol requires protobuf extension");
+        }
+        if (!extension_loaded("grpc")) {
+            throw new InvalidArgumentException("couchbase2:// protocol requires grpc extension");
+        }
         ClusterRegistry::registerConnectionHandler(
             "/^protostellar:\/\//",
             function (string $connectionString, ClusterOptions $options) {

--- a/composer.json
+++ b/composer.json
@@ -16,13 +16,15 @@
       "email": "sergey.avseyev@gmail.com"
     }
   ],
-  "require": {
-    "ext-json": "*",
+  "suggest": {
     "ext-grpc": "^1.15",
     "ext-protobuf": "^3.21",
     "google/protobuf": "^3.21",
     "grpc/grpc": "^1.42",
     "google/common-protos": "^3.1"
+  },
+  "require": {
+    "ext-json": "*"
   },
   "require-dev": {
     "ext-sockets": "*",


### PR DESCRIPTION
Hard dependency on gRPC in PHP might be problematic, so by relaxing the requirement we allow users to choose whether to install gRPC and instead check its presence runtime and throw exception if couchbase2:// protocol is being used while the extensions are not loaded.