### PR TITLE
PCBC-995: The SDK should throw an InvalidArgumentException when an empty VectorSearch is constructed

### DIFF
--- a/Couchbase/VectorQuery.php
+++ b/Couchbase/VectorQuery.php
@@ -33,7 +33,7 @@ class VectorQuery
     /**
      * @param string $vectorFieldName the document field that contains the vector
      * @param array<float>|string $vectorQuery the vector query to run. Cannot be empty. Either a vector array,
-     * or the vector query encoded into a base64 string.
+     * or a base64-encoded sequence of little-endian IEEE 754 floats.
      *
      * @since 4.1.7
      *

--- a/Couchbase/VectorSearch.php
+++ b/Couchbase/VectorSearch.php
@@ -20,6 +20,7 @@ declare(strict_types=1);
 
 namespace Couchbase;
 
+use Couchbase\Exception\InvalidArgumentException;
 use JsonSerializable;
 
 class VectorSearch implements JsonSerializable
@@ -31,12 +32,17 @@ class VectorSearch implements JsonSerializable
      * @param array<VectorQuery> $vectorQueries The vector queries to be run.
      * @param VectorSearchOptions|null $options The options to use on the vector queries
      *
+     * @throws InvalidArgumentException
+     *
      * @since 4.1.7
      *
      * @UNCOMMITTED: This API may change in the future.
      */
     public function __construct(array $vectorQueries, VectorSearchOptions $options = null)
     {
+        if (empty($vectorQueries)) {
+            throw new InvalidArgumentException("At least one vector query must be specified");
+        }
         $this->vectorQueries = $vectorQueries;
         $this->options = $options;
     }


### PR DESCRIPTION
Changes

- Added InvalidArguments check for vector search
- Improved codedoc regarding base64-encoded vector queries