### PR TITLE
PCBC-997: Do not export development files

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,6 @@
+/*.yaml export-ignore
+/.* export-ignore
+/bin export-ignore
+/compile_commands.json export-ignore
+/src export-ignore
+/tests export-ignore


### PR DESCRIPTION
Exclude C++ files, tests and development scripts, so that Packagist will not install them to the application ./vendor directory.