### PR TITLE
PCBC-1010: use explicit nullable types where applicable

### DIFF
--- a/Couchbase/AnalyticsOptions.php
+++ b/Couchbase/AnalyticsOptions.php
@@ -204,7 +204,7 @@ class AnalyticsOptions
         return $options->transcoder;
     }
 
-    public static function export(?AnalyticsOptions $options, string $scopeName = null, string $bucketName = null): array
+    public static function export(?AnalyticsOptions $options, ?string $scopeName = null, ?string $bucketName = null): array
     {
         if ($options == null) {
             return [

--- a/Couchbase/BinaryCollection.php
+++ b/Couchbase/BinaryCollection.php
@@ -78,7 +78,7 @@ class BinaryCollection implements BinaryCollectionInterface
      * @throws CouchbaseException
      * @since 4.0.0
      */
-    public function append(string $id, string $value, AppendOptions $options = null): MutationResult
+    public function append(string $id, string $value, ?AppendOptions $options = null): MutationResult
     {
         $response = Extension\documentAppend(
             $this->core,
@@ -105,7 +105,7 @@ class BinaryCollection implements BinaryCollectionInterface
      * @throws CouchbaseException
      * @since 4.0.0
      */
-    public function prepend(string $id, string $value, PrependOptions $options = null): MutationResult
+    public function prepend(string $id, string $value, ?PrependOptions $options = null): MutationResult
     {
         $response = Extension\documentPrepend(
             $this->core,
@@ -131,7 +131,7 @@ class BinaryCollection implements BinaryCollectionInterface
      * @throws CouchbaseException
      * @since 4.0.0
      */
-    public function increment(string $id, IncrementOptions $options = null): CounterResult
+    public function increment(string $id, ?IncrementOptions $options = null): CounterResult
     {
         $response = Extension\documentIncrement(
             $this->core,
@@ -156,7 +156,7 @@ class BinaryCollection implements BinaryCollectionInterface
      * @throws CouchbaseException
      * @since 4.0.0
      */
-    public function decrement(string $id, DecrementOptions $options = null): CounterResult
+    public function decrement(string $id, ?DecrementOptions $options = null): CounterResult
     {
         $response = Extension\documentDecrement(
             $this->core,

--- a/Couchbase/BinaryCollectionInterface.php
+++ b/Couchbase/BinaryCollectionInterface.php
@@ -24,11 +24,11 @@ interface BinaryCollectionInterface
 {
     public function name(): string;
 
-    public function append(string $id, string $value, AppendOptions $options = null): MutationResult;
+    public function append(string $id, string $value, ?AppendOptions $options = null): MutationResult;
 
-    public function prepend(string $id, string $value, PrependOptions $options = null): MutationResult;
+    public function prepend(string $id, string $value, ?PrependOptions $options = null): MutationResult;
 
-    public function increment(string $id, IncrementOptions $options = null): CounterResult;
+    public function increment(string $id, ?IncrementOptions $options = null): CounterResult;
 
-    public function decrement(string $id, DecrementOptions $options = null): CounterResult;
+    public function decrement(string $id, ?DecrementOptions $options = null): CounterResult;
 }

--- a/Couchbase/Bucket.php
+++ b/Couchbase/Bucket.php
@@ -123,7 +123,7 @@ class Bucket implements BucketInterface
      * @return ViewResult
      * @since 4.0.0
      */
-    public function viewQuery(string $designDoc, string $viewName, ViewOptions $options = null): ViewResult
+    public function viewQuery(string $designDoc, string $viewName, ?ViewOptions $options = null): ViewResult
     {
         $opts = ViewOptions::export($options);
         $namespace = $opts["namespace"];
@@ -195,7 +195,7 @@ class Bucket implements BucketInterface
      * @deprecated - see cluster->diagnostics
      * @since 4.0.0
      */
-    public function diagnostics(string $reportId = null)
+    public function diagnostics(?string $reportId = null)
     {
         if ($reportId == null) {
             $reportId = uniqid();

--- a/Couchbase/BucketInterface.php
+++ b/Couchbase/BucketInterface.php
@@ -30,5 +30,5 @@ interface BucketInterface
 
     public function name(): string;
 
-    public function viewQuery(string $designDoc, string $viewName, ViewOptions $options = null): ViewResult;
+    public function viewQuery(string $designDoc, string $viewName, ?ViewOptions $options = null): ViewResult;
 }

--- a/Couchbase/Cluster.php
+++ b/Couchbase/Cluster.php
@@ -184,7 +184,7 @@ class Cluster implements ClusterInterface
      * @throws CouchbaseException
      * @since 4.0.0
      */
-    public function analyticsQuery(string $statement, AnalyticsOptions $options = null): AnalyticsResult
+    public function analyticsQuery(string $statement, ?AnalyticsOptions $options = null): AnalyticsResult
     {
         $result = Extension\analyticsQuery($this->core, $statement, AnalyticsOptions::export($options));
 
@@ -202,7 +202,7 @@ class Cluster implements ClusterInterface
      * @return SearchResult
      * @since 4.0.0
      */
-    public function searchQuery(string $indexName, SearchQuery $query, SearchOptions $options = null): SearchResult
+    public function searchQuery(string $indexName, SearchQuery $query, ?SearchOptions $options = null): SearchResult
     {
         $result = Extension\searchQuery($this->core, $indexName, json_encode($query), SearchOptions::export($options));
 
@@ -222,7 +222,7 @@ class Cluster implements ClusterInterface
      * @throws InvalidArgumentException
      * @since 4.1.7
      */
-    public function search(string $indexName, SearchRequest $request, SearchOptions $options = null): SearchResult
+    public function search(string $indexName, SearchRequest $request, ?SearchOptions $options = null): SearchResult
     {
         $exportedRequest = SearchRequest::export($request);
         $exportedOptions = SearchOptions::export($options);
@@ -329,7 +329,7 @@ class Cluster implements ClusterInterface
      *
      * @since 4.0.0
      */
-    public function diagnostics(string $reportId = null)
+    public function diagnostics(?string $reportId = null)
     {
         if ($reportId == null) {
             $reportId = uniqid();

--- a/Couchbase/ClusterInterface.php
+++ b/Couchbase/ClusterInterface.php
@@ -26,7 +26,7 @@ interface ClusterInterface
 
     public function query(string $statement, ?QueryOptions $options = null): QueryResult;
 
-    public function analyticsQuery(string $statement, AnalyticsOptions $options = null): AnalyticsResult;
+    public function analyticsQuery(string $statement, ?AnalyticsOptions $options = null): AnalyticsResult;
 
-    public function searchQuery(string $indexName, SearchQuery $query, SearchOptions $options = null): SearchResult;
+    public function searchQuery(string $indexName, SearchQuery $query, ?SearchOptions $options = null): SearchResult;
 }

--- a/Couchbase/Collection.php
+++ b/Couchbase/Collection.php
@@ -113,7 +113,7 @@ class Collection implements CollectionInterface
      * @throws CouchbaseException
      * @since 4.0.0
      */
-    public function get(string $id, GetOptions $options = null): GetResult
+    public function get(string $id, ?GetOptions $options = null): GetResult
     {
         $response = Extension\documentGet(
             $this->core,
@@ -137,7 +137,7 @@ class Collection implements CollectionInterface
      * @throws CouchbaseException
      * @since 4.0.0
      */
-    public function exists(string $id, ExistsOptions $options = null): ExistsResult
+    public function exists(string $id, ?ExistsOptions $options = null): ExistsResult
     {
         $response = Extension\documentExists(
             $this->core,
@@ -164,7 +164,7 @@ class Collection implements CollectionInterface
      * @throws CouchbaseException
      * @since 4.0.0
      */
-    public function getAndLock(string $id, int $lockTimeSeconds, GetAndLockOptions $options = null): GetResult
+    public function getAndLock(string $id, int $lockTimeSeconds, ?GetAndLockOptions $options = null): GetResult
     {
         $response = Extension\documentGetAndLock(
             $this->core,
@@ -191,7 +191,7 @@ class Collection implements CollectionInterface
      * @throws CouchbaseException
      * @since 4.0.0
      */
-    public function getAndTouch(string $id, $expiry, GetAndTouchOptions $options = null): GetResult
+    public function getAndTouch(string $id, $expiry, ?GetAndTouchOptions $options = null): GetResult
     {
         if ($expiry instanceof DateTimeInterface) {
             $expirySeconds = $expiry->getTimestamp();
@@ -223,7 +223,7 @@ class Collection implements CollectionInterface
      * @throws TimeoutException
      * @since 4.0.1
      */
-    public function getAnyReplica(string $id, GetAnyReplicaOptions $options = null): GetReplicaResult
+    public function getAnyReplica(string $id, ?GetAnyReplicaOptions $options = null): GetReplicaResult
     {
         $response = Extension\documentGetAnyReplica(
             $this->core,
@@ -248,7 +248,7 @@ class Collection implements CollectionInterface
      * @throws TimeoutException
      * @since 4.0.0
      */
-    public function getAllReplicas(string $id, GetAllReplicasOptions $options = null): array
+    public function getAllReplicas(string $id, ?GetAllReplicasOptions $options = null): array
     {
         $responses = Extension\documentGetAllReplicas(
             $this->core,
@@ -278,7 +278,7 @@ class Collection implements CollectionInterface
      * @throws CouchbaseException
      * @since 4.0.0
      */
-    public function upsert(string $id, $value, UpsertOptions $options = null): MutationResult
+    public function upsert(string $id, $value, ?UpsertOptions $options = null): MutationResult
     {
         $encoded = UpsertOptions::encodeDocument($options, $value);
         $response = Extension\documentUpsert(
@@ -307,7 +307,7 @@ class Collection implements CollectionInterface
      * @throws CouchbaseException
      * @since 4.0.0
      */
-    public function insert(string $id, $value, InsertOptions $options = null): MutationResult
+    public function insert(string $id, $value, ?InsertOptions $options = null): MutationResult
     {
         $encoded = InsertOptions::encodeDocument($options, $value);
         $response = Extension\documentInsert(
@@ -337,7 +337,7 @@ class Collection implements CollectionInterface
      * @throws CouchbaseException
      * @since 4.0.0
      */
-    public function replace(string $id, $value, ReplaceOptions $options = null): MutationResult
+    public function replace(string $id, $value, ?ReplaceOptions $options = null): MutationResult
     {
         $encoded = ReplaceOptions::encodeDocument($options, $value);
         $response = Extension\documentReplace(
@@ -366,7 +366,7 @@ class Collection implements CollectionInterface
      * @throws DocumentNotFoundException
      * @since 4.0.0
      */
-    public function remove(string $id, RemoveOptions $options = null): MutationResult
+    public function remove(string $id, ?RemoveOptions $options = null): MutationResult
     {
         $response = Extension\documentRemove(
             $this->core,
@@ -394,7 +394,7 @@ class Collection implements CollectionInterface
      * @throws CouchbaseException
      * @since 4.0.0
      */
-    public function unlock(string $id, string $cas, UnlockOptions $options = null): Result
+    public function unlock(string $id, string $cas, ?UnlockOptions $options = null): Result
     {
         $response = Extension\documentUnlock(
             $this->core,
@@ -421,7 +421,7 @@ class Collection implements CollectionInterface
      * @throws CouchbaseException
      * @since 4.0.0
      */
-    public function touch(string $id, $expiry, TouchOptions $options = null): MutationResult
+    public function touch(string $id, $expiry, ?TouchOptions $options = null): MutationResult
     {
         if ($expiry instanceof DateTimeInterface) {
             $expirySeconds = $expiry->getTimestamp();
@@ -453,7 +453,7 @@ class Collection implements CollectionInterface
      * @throws CouchbaseException
      * @since 4.0.0
      */
-    public function lookupIn(string $id, array $specs, LookupInOptions $options = null): LookupInResult
+    public function lookupIn(string $id, array $specs, ?LookupInOptions $options = null): LookupInResult
     {
         $encoded = array_map(
             function (LookupInSpec $item) {
@@ -489,7 +489,7 @@ class Collection implements CollectionInterface
      * @throws CouchbaseException
      * @since 4.1.6
      */
-    public function lookupInAnyReplica(string $id, array $specs, LookupInAnyReplicaOptions $options = null): LookupInReplicaResult
+    public function lookupInAnyReplica(string $id, array $specs, ?LookupInAnyReplicaOptions $options = null): LookupInReplicaResult
     {
         $encoded = array_map(
             function (LookupInSpec $item) {
@@ -526,7 +526,7 @@ class Collection implements CollectionInterface
      * @throws CouchbaseException
      * @since 4.1.6
      */
-    public function lookupInAllReplicas(string $id, array $specs, LookupInAllReplicasOptions $options = null): array
+    public function lookupInAllReplicas(string $id, array $specs, ?LookupInAllReplicasOptions $options = null): array
     {
         $encoded = array_map(
             function (LookupInSpec $item) {
@@ -568,7 +568,7 @@ class Collection implements CollectionInterface
      * @throws CouchbaseException
      * @since 4.0.0
      */
-    public function mutateIn(string $id, array $specs, MutateInOptions $options = null): MutateInResult
+    public function mutateIn(string $id, array $specs, ?MutateInOptions $options = null): MutateInResult
     {
         $encoded = array_map(
             function (MutateInSpec $item) use ($options) {
@@ -598,7 +598,7 @@ class Collection implements CollectionInterface
      * @return array<GetResult> array of GetResult, one for each of the entries
      * @since 4.0.0
      */
-    public function getMulti(array $ids, GetOptions $options = null): array
+    public function getMulti(array $ids, ?GetOptions $options = null): array
     {
         $responses = Extension\documentGetMulti(
             $this->core,
@@ -630,7 +630,7 @@ class Collection implements CollectionInterface
      * @throws InvalidArgumentException
      * @since 4.1.6
      */
-    public function scan(ScanType $scanType, ScanOptions $options = null): ScanResults
+    public function scan(ScanType $scanType, ?ScanOptions $options = null): ScanResults
     {
         if ($scanType instanceof RangeScan) {
             $type = RangeScan::export($scanType);
@@ -664,7 +664,7 @@ class Collection implements CollectionInterface
      * @throws UnsupportedOperationException
      * @since 4.0.0
      */
-    public function removeMulti(array $entries, RemoveOptions $options = null): array
+    public function removeMulti(array $entries, ?RemoveOptions $options = null): array
     {
         $responses = Extension\documentRemoveMulti(
             $this->core,
@@ -693,7 +693,7 @@ class Collection implements CollectionInterface
      * @throws InvalidArgumentException
      * @since 4.0.0
      */
-    public function upsertMulti(array $entries, UpsertOptions $options = null): array
+    public function upsertMulti(array $entries, ?UpsertOptions $options = null): array
     {
         $encodedEntries = array_map(
             function (array $entry) use ($options) {

--- a/Couchbase/CollectionInterface.php
+++ b/Couchbase/CollectionInterface.php
@@ -28,33 +28,33 @@ interface CollectionInterface
 
     public function name(): string;
 
-    public function get(string $id, GetOptions $options = null): GetResult;
+    public function get(string $id, ?GetOptions $options = null): GetResult;
 
-    public function exists(string $id, ExistsOptions $options = null): ExistsResult;
+    public function exists(string $id, ?ExistsOptions $options = null): ExistsResult;
 
-    public function getAndLock(string $id, int $lockTimeSeconds, GetAndLockOptions $options = null): GetResult;
+    public function getAndLock(string $id, int $lockTimeSeconds, ?GetAndLockOptions $options = null): GetResult;
 
-    public function getAndTouch(string $id, $expiry, GetAndTouchOptions $options = null): GetResult;
+    public function getAndTouch(string $id, $expiry, ?GetAndTouchOptions $options = null): GetResult;
 
-    public function getAnyReplica(string $id, GetAnyReplicaOptions $options = null): GetReplicaResult;
+    public function getAnyReplica(string $id, ?GetAnyReplicaOptions $options = null): GetReplicaResult;
 
-    public function getAllReplicas(string $id, GetAllReplicasOptions $options = null): array;
+    public function getAllReplicas(string $id, ?GetAllReplicasOptions $options = null): array;
 
-    public function upsert(string $id, $value, UpsertOptions $options = null): MutationResult;
+    public function upsert(string $id, $value, ?UpsertOptions $options = null): MutationResult;
 
-    public function insert(string $id, $value, InsertOptions $options = null): MutationResult;
+    public function insert(string $id, $value, ?InsertOptions $options = null): MutationResult;
 
-    public function replace(string $id, $value, ReplaceOptions $options = null): MutationResult;
+    public function replace(string $id, $value, ?ReplaceOptions $options = null): MutationResult;
 
-    public function remove(string $id, RemoveOptions $options = null): MutationResult;
+    public function remove(string $id, ?RemoveOptions $options = null): MutationResult;
 
-    public function unlock(string $id, string $cas, UnlockOptions $options = null): Result;
+    public function unlock(string $id, string $cas, ?UnlockOptions $options = null): Result;
 
-    public function touch(string $id, $expiry, TouchOptions $options = null): MutationResult;
+    public function touch(string $id, $expiry, ?TouchOptions $options = null): MutationResult;
 
-    public function lookupIn(string $id, array $specs, LookupInOptions $options = null): LookupInResult;
+    public function lookupIn(string $id, array $specs, ?LookupInOptions $options = null): LookupInResult;
 
-    public function mutateIn(string $id, array $specs, MutateInOptions $options = null): MutateInResult;
+    public function mutateIn(string $id, array $specs, ?MutateInOptions $options = null): MutateInResult;
 
     public function binary(): BinaryCollectionInterface;
 }

--- a/Couchbase/Exception/CouchbaseException.php
+++ b/Couchbase/Exception/CouchbaseException.php
@@ -30,7 +30,7 @@ class CouchbaseException extends Exception
 {
     private ?array $context;
 
-    public function __construct($message = "", $code = 0, Throwable $previous = null, array $context = null)
+    public function __construct($message = "", $code = 0, ?Throwable $previous = null, ?array $context = null)
     {
         parent::__construct($message, $code, $previous);
         $this->context = $context;

--- a/Couchbase/GeoDistanceSearchQuery.php
+++ b/Couchbase/GeoDistanceSearchQuery.php
@@ -42,7 +42,7 @@ class GeoDistanceSearchQuery implements JsonSerializable, SearchQuery
      *
      * @since 4.0.0
      */
-    public function __construct(float $longitude, float $latitude, string $distance = null)
+    public function __construct(float $longitude, float $latitude, ?string $distance = null)
     {
         $this->longitude = $longitude;
         $this->latitude = $latitude;
@@ -59,7 +59,7 @@ class GeoDistanceSearchQuery implements JsonSerializable, SearchQuery
      * @return GeoDistanceSearchQuery
      * @since 4.1.7
      */
-    public static function build(float $longitude, float $latitude, string $distance = null): GeoDistanceSearchQuery
+    public static function build(float $longitude, float $latitude, ?string $distance = null): GeoDistanceSearchQuery
     {
         return new GeoDistanceSearchQuery($longitude, $latitude, $distance);
     }

--- a/Couchbase/Management/AnalyticsIndexManager.php
+++ b/Couchbase/Management/AnalyticsIndexManager.php
@@ -47,7 +47,7 @@ class AnalyticsIndexManager
      *
      * @since 4.2.4
      */
-    public function createDataverse(string $dataverseName, CreateAnalyticsDataverseOptions $options = null): void
+    public function createDataverse(string $dataverseName, ?CreateAnalyticsDataverseOptions $options = null): void
     {
         Extension\analyticsDataverseCreate($this->core, $dataverseName, CreateAnalyticsDataverseOptions::export($options));
     }
@@ -60,7 +60,7 @@ class AnalyticsIndexManager
      *
      * @since 4.2.4
      */
-    public function dropDataverse(string $dataverseName, DropAnalyticsDataverseOptions $options = null): void
+    public function dropDataverse(string $dataverseName, ?DropAnalyticsDataverseOptions $options = null): void
     {
         Extension\analyticsDataverseDrop($this->core, $dataverseName, DropAnalyticsDataverseOptions::export($options));
     }
@@ -74,7 +74,7 @@ class AnalyticsIndexManager
      *
      * @since 4.2.4
      */
-    public function createDataset(string $datasetName, string $bucketName, CreateAnalyticsDatasetOptions $options = null): void
+    public function createDataset(string $datasetName, string $bucketName, ?CreateAnalyticsDatasetOptions $options = null): void
     {
         Extension\analyticsDatasetCreate($this->core, $datasetName, $bucketName, CreateAnalyticsDatasetOptions::export($options));
     }
@@ -87,7 +87,7 @@ class AnalyticsIndexManager
      *
      * @since 4.2.4
      */
-    public function dropDataset(string $datasetName, DropAnalyticsDatasetOptions $options = null): void
+    public function dropDataset(string $datasetName, ?DropAnalyticsDatasetOptions $options = null): void
     {
         Extension\analyticsDatasetDrop($this->core, $datasetName, DropAnalyticsDatasetOptions::export($options));
     }
@@ -100,7 +100,7 @@ class AnalyticsIndexManager
      * @return array an array of {@link AnalyticsDataset}
      * @since 4.2.4
      */
-    public function getAllDatasets(GetAllAnalyticsDatasetsOptions $options = null): array
+    public function getAllDatasets(?GetAllAnalyticsDatasetsOptions $options = null): array
     {
         $result = Extension\analyticsDatasetGetAll($this->core, GetAllAnalyticsDatasetsOptions::export($options));
         $datasets = [];
@@ -120,7 +120,7 @@ class AnalyticsIndexManager
      *
      * @since 4.2.4
      */
-    public function createIndex(string $datasetName, string $indexName, array $fields, CreateAnalyticsIndexOptions $options = null): void
+    public function createIndex(string $datasetName, string $indexName, array $fields, ?CreateAnalyticsIndexOptions $options = null): void
     {
         Extension\analyticsIndexCreate($this->core, $datasetName, $indexName, $fields, CreateAnalyticsIndexOptions::export($options));
     }
@@ -134,7 +134,7 @@ class AnalyticsIndexManager
      *
      * @since 4.2.4
      */
-    public function dropIndex(string $datasetName, string $indexName, DropAnalyticsIndexOptions $options = null): void
+    public function dropIndex(string $datasetName, string $indexName, ?DropAnalyticsIndexOptions $options = null): void
     {
         Extension\analyticsIndexDrop($this->core, $datasetName, $indexName, DropAnalyticsIndexOptions::export($options));
     }
@@ -147,7 +147,7 @@ class AnalyticsIndexManager
      * @return array array of {@link AnalyticsIndex}
      * @since 4.2.4
      */
-    public function getAllIndexes(GetAllAnalyticsIndexesOptions $options = null): array
+    public function getAllIndexes(?GetAllAnalyticsIndexesOptions $options = null): array
     {
         $result = Extension\analyticsIndexGetAll($this->core, GetAllAnalyticsIndexesOptions::export($options));
         $indexes = [];
@@ -164,7 +164,7 @@ class AnalyticsIndexManager
      *
      * @since 4.2.4
      */
-    public function connectLink(ConnectAnalyticsLinkOptions $options = null): void
+    public function connectLink(?ConnectAnalyticsLinkOptions $options = null): void
     {
         Extension\analyticsLinkConnect($this->core, ConnectAnalyticsLinkOptions::export($options));
     }
@@ -176,7 +176,7 @@ class AnalyticsIndexManager
      *
      * @since 4.2.4
      */
-    public function disconnectLink(DisconnectAnalyticsLinkOptions $options = null): void
+    public function disconnectLink(?DisconnectAnalyticsLinkOptions $options = null): void
     {
         Extension\analyticsLinkDisconnect($this->core, DisconnectAnalyticsLinkOptions::export($options));
     }
@@ -190,7 +190,7 @@ class AnalyticsIndexManager
      * and values are an associative array of datasets to number of pending mutations.
      * @since 4.2.4
      */
-    public function getPendingMutations(GetAnalyticsPendingMutationsOptions $options = null): array
+    public function getPendingMutations(?GetAnalyticsPendingMutationsOptions $options = null): array
     {
         $results = Extension\analyticsPendingMutationsGet($this->core, GetAnalyticsPendingMutationsOptions::export($options));
 
@@ -209,7 +209,7 @@ class AnalyticsIndexManager
      *
      * @since 4.2.4
      */
-    public function createLink(AnalyticsLink $link, CreateAnalyticsLinkOptions $options = null): void
+    public function createLink(AnalyticsLink $link, ?CreateAnalyticsLinkOptions $options = null): void
     {
         Extension\analyticsLinkCreate($this->core, $link->export(), CreateAnalyticsLinkOptions::export($options));
     }
@@ -226,7 +226,7 @@ class AnalyticsIndexManager
      *
      * @since 4.2.4
      */
-    public function replaceLink(AnalyticsLink $link, ReplaceAnalyticsLinkOptions $options = null): void
+    public function replaceLink(AnalyticsLink $link, ?ReplaceAnalyticsLinkOptions $options = null): void
     {
         Extension\analyticsLinkReplace($this->core, $link->export(), ReplaceAnalyticsLinkOptions::export($options));
     }
@@ -240,7 +240,7 @@ class AnalyticsIndexManager
      *
      * @since 4.2.4
      */
-    public function dropLink(string $linkName, string $dataverseName, DropAnalyticsLinkOptions $options = null): void
+    public function dropLink(string $linkName, string $dataverseName, ?DropAnalyticsLinkOptions $options = null): void
     {
         Extension\analyticsLinkDrop($this->core, $linkName, $dataverseName, DropAnalyticsLinkOptions::export($options));
     }
@@ -256,7 +256,7 @@ class AnalyticsIndexManager
      * @return array array of {@link CouchbaseRemoteAnalyticsLink}, {@link S3ExternalAnalyticsLink}, or {@link AzureBlobExternalAnalyticsLink}
      * @since 4.2.4
      */
-    public function getLinks(GetAnalyticsLinksOptions $options = null): array
+    public function getLinks(?GetAnalyticsLinksOptions $options = null): array
     {
         $result = Extension\analyticsLinkGetAll($this->core, GetAnalyticsLinksOptions::export($options));
         $links = [];

--- a/Couchbase/Management/BucketManager.php
+++ b/Couchbase/Management/BucketManager.php
@@ -46,7 +46,7 @@ class BucketManager implements BucketManagerInterface
      * @param CreateBucketOptions|null $options the options to use when creating the bucket.
      * @since 4.0.0
      */
-    public function createBucket(BucketSettings $settings, CreateBucketOptions $options = null)
+    public function createBucket(BucketSettings $settings, ?CreateBucketOptions $options = null)
     {
         Extension\bucketCreate($this->core, BucketSettings::export($settings), CreateBucketOptions::export($options));
     }
@@ -58,7 +58,7 @@ class BucketManager implements BucketManagerInterface
      * @param UpdateBucketOptions|null $options the options to use when updating the bucket.
      * @since 4.0.0
      */
-    public function updateBucket(BucketSettings $settings, UpdateBucketOptions $options = null)
+    public function updateBucket(BucketSettings $settings, ?UpdateBucketOptions $options = null)
     {
         Extension\bucketUpdate($this->core, BucketSettings::export($settings), UpdateBucketOptions::export($options));
     }
@@ -82,7 +82,7 @@ class BucketManager implements BucketManagerInterface
      * @param DropBucketOptions|null $options the options to use when dropping the bucket.
      * @since 4.0.0
      */
-    public function dropBucket(string $name, DropBucketOptions $options = null)
+    public function dropBucket(string $name, ?DropBucketOptions $options = null)
     {
         Extension\bucketDrop($this->core, $name, DropBucketOptions::export($options));
     }
@@ -94,7 +94,7 @@ class BucketManager implements BucketManagerInterface
      * @param GetBucketOptions|null $options the options to use when getting the bucket.
      * @since 4.0.0
      */
-    public function getBucket(string $name, GetBucketOptions $options = null): BucketSettings
+    public function getBucket(string $name, ?GetBucketOptions $options = null): BucketSettings
     {
         $result = Extension\bucketGet($this->core, $name, GetBucketOptions::export($options));
         return BucketSettings::import($result);
@@ -107,7 +107,7 @@ class BucketManager implements BucketManagerInterface
      *
      * @since 4.0.0
      */
-    public function getAllBuckets(GetAllBucketsOptions $options = null): array
+    public function getAllBuckets(?GetAllBucketsOptions $options = null): array
     {
         $result = Extension\bucketGetAll($this->core, GetAllBucketsOptions::export($options));
         $buckets = [];
@@ -124,7 +124,7 @@ class BucketManager implements BucketManagerInterface
      * @param FlushBucketOptions|null $options the options to use when flushing the bucket.
      * @since 4.0.0
      */
-    public function flush(string $name, FlushBucketOptions $options = null)
+    public function flush(string $name, ?FlushBucketOptions $options = null)
     {
         Extension\bucketFlush($this->core, $name, FlushBucketOptions::export($options));
     }

--- a/Couchbase/Management/BucketManagerInterface.php
+++ b/Couchbase/Management/BucketManagerInterface.php
@@ -1,18 +1,36 @@
 <?php
 
+/**
+ * Copyright 2014-Present Couchbase, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+declare(strict_types=1);
+
 namespace Couchbase\Management;
 
 interface BucketManagerInterface
 {
-    public function createBucket(BucketSettings $settings, CreateBucketOptions $options = null);
+    public function createBucket(BucketSettings $settings, ?CreateBucketOptions $options = null);
 
-    public function updateBucket(BucketSettings $settings, UpdateBucketOptions $options = null);
+    public function updateBucket(BucketSettings $settings, ?UpdateBucketOptions $options = null);
 
-    public function dropBucket(string $name, DropBucketOptions $options = null);
+    public function dropBucket(string $name, ?DropBucketOptions $options = null);
 
-    public function getBucket(string $name, GetBucketOptions $options = null): BucketSettings;
+    public function getBucket(string $name, ?GetBucketOptions $options = null): BucketSettings;
 
-    public function getAllBuckets(GetAllBucketsOptions $options = null): array;
+    public function getAllBuckets(?GetAllBucketsOptions $options = null): array;
 
-    public function flush(string $name, FlushBucketOptions $options = null);
+    public function flush(string $name, ?FlushBucketOptions $options = null);
 }

--- a/Couchbase/Management/CollectionManager.php
+++ b/Couchbase/Management/CollectionManager.php
@@ -44,7 +44,7 @@ class CollectionManager implements CollectionManagerInterface
      * @see ScopeSpec
      * @return array array of scopes within the bucket
      */
-    public function getAllScopes(GetAllScopesOptions $options = null): array
+    public function getAllScopes(?GetAllScopesOptions $options = null): array
     {
         $result = Extension\scopeGetAll($this->core, $this->bucketName, GetAllScopesOptions::export($options));
         $scopes = [];
@@ -61,7 +61,7 @@ class CollectionManager implements CollectionManagerInterface
      * @param CreateScopeOptions|null $options the options to use when creating a scope
      * @since 4.1.3
      */
-    public function createScope(string $name, CreateScopeOptions $options = null)
+    public function createScope(string $name, ?CreateScopeOptions $options = null)
     {
         Extension\scopeCreate($this->core, $this->bucketName, $name, CreateScopeOptions::export($options));
     }
@@ -73,7 +73,7 @@ class CollectionManager implements CollectionManagerInterface
      * @param DropScopeOptions|null $options the options to use when dropping a scope
      * @since 4.1.3
      */
-    public function dropScope(string $name, DropScopeOptions $options = null)
+    public function dropScope(string $name, ?DropScopeOptions $options = null)
     {
         Extension\scopeDrop($this->core, $this->bucketName, $name, DropScopeOptions::export($options));
     }
@@ -142,7 +142,7 @@ class CollectionManager implements CollectionManagerInterface
      * @param UpdateCollectionOptions|null $options The options to use when updating the collection
      * @since 4.1.6
      */
-    public function updateCollection(string $scopeName, string $collectionName, UpdateCollectionSettings $settings, UpdateCollectionOptions $options = null)
+    public function updateCollection(string $scopeName, string $collectionName, UpdateCollectionSettings $settings, ?UpdateCollectionOptions $options = null)
     {
         Extension\collectionUpdate($this->core, $this->bucketName, $scopeName, $collectionName, UpdateCollectionSettings::export($settings), UpdateBucketOptions::export($options));
     }

--- a/Couchbase/Management/CollectionManagerInterface.php
+++ b/Couchbase/Management/CollectionManagerInterface.php
@@ -1,18 +1,34 @@
 <?php
 
+/**
+ * Copyright 2014-Present Couchbase, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 namespace Couchbase\Management;
 
 interface CollectionManagerInterface
 {
-    public function getAllScopes(GetAllScopesOptions $options = null): array;
+    public function getAllScopes(?GetAllScopesOptions $options = null): array;
 
-    public function createScope(string $name, CreateScopeOptions $options = null);
+    public function createScope(string $name, ?CreateScopeOptions $options = null);
 
-    public function dropScope(string $name, DropScopeOptions $options = null);
+    public function dropScope(string $name, ?DropScopeOptions $options = null);
 
     public function createCollection($scopeName, $collectionName = null, $settings = null, $options = null);
 
     public function dropCollection($scopeName, $collectionName = null, $options = null);
 
-    public function updateCollection(string $scopeName, string $collectionName, UpdateCollectionSettings $settings, UpdateCollectionOptions $options = null);
+    public function updateCollection(string $scopeName, string $collectionName, UpdateCollectionSettings $settings, ?UpdateCollectionOptions $options = null);
 }

--- a/Couchbase/Management/CollectionQueryIndexManager.php
+++ b/Couchbase/Management/CollectionQueryIndexManager.php
@@ -59,7 +59,7 @@ class CollectionQueryIndexManager implements CollectionQueryIndexManagerInterfac
      * @throws InvalidArgumentException
      * @since 4.1.2
      */
-    public function getAllIndexes(GetAllQueryIndexesOptions $options = null): array
+    public function getAllIndexes(?GetAllQueryIndexesOptions $options = null): array
     {
         $exported = GetAllQueryIndexesOptions::export($options);
         $this->checkOptions($exported);
@@ -82,7 +82,7 @@ class CollectionQueryIndexManager implements CollectionQueryIndexManagerInterfac
      * @throws InvalidArgumentException
      * @since 4.1.2
      */
-    public function createIndex(string $indexName, array $keys, CreateQueryIndexOptions $options = null)
+    public function createIndex(string $indexName, array $keys, ?CreateQueryIndexOptions $options = null)
     {
         $exported = CreateQueryIndexOptions::export($options);
         $this->checkOptions($exported);
@@ -97,7 +97,7 @@ class CollectionQueryIndexManager implements CollectionQueryIndexManagerInterfac
      * @throws InvalidArgumentException
      * @since 4.1.2
      */
-    public function createPrimaryIndex(CreateQueryPrimaryIndexOptions $options = null)
+    public function createPrimaryIndex(?CreateQueryPrimaryIndexOptions $options = null)
     {
         $exported = CreateQueryPrimaryIndexOptions::export($options);
         $this->checkOptions($exported);
@@ -113,7 +113,7 @@ class CollectionQueryIndexManager implements CollectionQueryIndexManagerInterfac
      * @throws InvalidArgumentException
      * @since 4.1.2
      */
-    public function dropIndex(string $indexName, DropQueryIndexOptions $options = null)
+    public function dropIndex(string $indexName, ?DropQueryIndexOptions $options = null)
     {
         $exported = DropQueryIndexOptions::export($options);
         $this->checkOptions($exported);
@@ -128,7 +128,7 @@ class CollectionQueryIndexManager implements CollectionQueryIndexManagerInterfac
      * @throws InvalidArgumentException
      * @since 4.1.2
      */
-    public function dropPrimaryIndex(DropQueryPrimaryIndexOptions $options = null)
+    public function dropPrimaryIndex(?DropQueryPrimaryIndexOptions $options = null)
     {
         $exported = DropQueryPrimaryIndexOptions::export($options);
         $this->checkOptions($exported);
@@ -143,7 +143,7 @@ class CollectionQueryIndexManager implements CollectionQueryIndexManagerInterfac
      * @throws InvalidArgumentException
      * @since 4.1.2
      */
-    public function buildDeferredIndexes(BuildQueryIndexesOptions $options = null)
+    public function buildDeferredIndexes(?BuildQueryIndexesOptions $options = null)
     {
         $exported = BuildQueryIndexesOptions::export($options);
         $this->checkOptions($exported);
@@ -160,7 +160,7 @@ class CollectionQueryIndexManager implements CollectionQueryIndexManagerInterfac
      * @throws UnambiguousTimeoutException|InvalidArgumentException
      * @since 4.1.2
      */
-    public function watchIndexes(array $indexNames, int $timeoutMilliseconds, WatchQueryIndexesOptions $options = null)
+    public function watchIndexes(array $indexNames, int $timeoutMilliseconds, ?WatchQueryIndexesOptions $options = null)
     {
         $exported = WatchQueryIndexesOptions::export($options);
         $this->checkOptions($exported);

--- a/Couchbase/Management/CollectionQueryIndexManagerInterface.php
+++ b/Couchbase/Management/CollectionQueryIndexManagerInterface.php
@@ -1,20 +1,36 @@
 <?php
 
+/**
+ * Copyright 2014-Present Couchbase, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 namespace Couchbase\Management;
 
 interface CollectionQueryIndexManagerInterface
 {
-    public function getAllIndexes(GetAllQueryIndexesOptions $options = null): array;
+    public function getAllIndexes(?GetAllQueryIndexesOptions $options = null): array;
 
-    public function createIndex(string $indexName, array $fields, CreateQueryIndexOptions $options = null);
+    public function createIndex(string $indexName, array $fields, ?CreateQueryIndexOptions $options = null);
 
-    public function createPrimaryIndex(CreateQueryPrimaryIndexOptions $options = null);
+    public function createPrimaryIndex(?CreateQueryPrimaryIndexOptions $options = null);
 
-    public function dropIndex(string $indexName, DropQueryIndexOptions $options = null);
+    public function dropIndex(string $indexName, ?DropQueryIndexOptions $options = null);
 
-    public function dropPrimaryIndex(DropQueryPrimaryIndexOptions $options = null);
+    public function dropPrimaryIndex(?DropQueryPrimaryIndexOptions $options = null);
 
-    public function buildDeferredIndexes(BuildQueryIndexesOptions $options = null);
+    public function buildDeferredIndexes(?BuildQueryIndexesOptions $options = null);
 
-    public function watchIndexes(array $indexNames, int $timeoutMilliseconds, WatchQueryIndexesOptions $options = null);
+    public function watchIndexes(array $indexNames, int $timeoutMilliseconds, ?WatchQueryIndexesOptions $options = null);
 }

--- a/Couchbase/Management/CollectionSpec.php
+++ b/Couchbase/Management/CollectionSpec.php
@@ -33,7 +33,7 @@ class CollectionSpec
      * @param int|null $maxExpiry
      * @since 4.1.3
      */
-    public function __construct(string $name, string $scopeName, int $maxExpiry = null, bool $history = null)
+    public function __construct(string $name, string $scopeName, ?int $maxExpiry = null, ?bool $history = null)
     {
         $this->name = $name;
         $this->scopeName = $scopeName;
@@ -50,7 +50,7 @@ class CollectionSpec
      * @return CollectionSpec
      * @since 4.1.3
      */
-    public static function build(string $name, string $scopeName, int $maxExpiry = null, bool $history = null): CollectionSpec
+    public static function build(string $name, string $scopeName, ?int $maxExpiry = null, ?bool $history = null): CollectionSpec
     {
         return new CollectionSpec($name, $scopeName, $maxExpiry, $history);
     }

--- a/Couchbase/Management/CreateCollectionSettings.php
+++ b/Couchbase/Management/CreateCollectionSettings.php
@@ -31,7 +31,7 @@ class CreateCollectionSettings
     /**
      * @throws InvalidArgumentException
      */
-    public function __construct(int $maxExpiry = null, bool $history = null)
+    public function __construct(?int $maxExpiry = null, ?bool $history = null)
     {
         if ($maxExpiry && $maxExpiry < -1) {
             throw new InvalidArgumentException("Collection max expiry must be greater than or equal to -1.");
@@ -43,7 +43,7 @@ class CreateCollectionSettings
     /**
      * @throws InvalidArgumentException
      */
-    public static function build(int $maxExpiry = null, bool $history = null): CreateCollectionSettings
+    public static function build(?int $maxExpiry = null, ?bool $history = null): CreateCollectionSettings
     {
         return new CreateCollectionSettings($maxExpiry, $history);
     }

--- a/Couchbase/Management/QueryIndexManager.php
+++ b/Couchbase/Management/QueryIndexManager.php
@@ -50,7 +50,7 @@ class QueryIndexManager implements QueryIndexManagerInterface
      * @return array
      * @since 4.0.0
      */
-    public function getAllIndexes(string $bucketName, GetAllQueryIndexesOptions $options = null): array
+    public function getAllIndexes(string $bucketName, ?GetAllQueryIndexesOptions $options = null): array
     {
         $responses = Extension\queryIndexGetAll($this->core, $bucketName, GetAllQueryIndexesOptions::export($options));
         return array_map(
@@ -71,7 +71,7 @@ class QueryIndexManager implements QueryIndexManagerInterface
      *
      * @since 4.0.0
      */
-    public function createIndex(string $bucketName, string $indexName, array $keys, CreateQueryIndexOptions $options = null)
+    public function createIndex(string $bucketName, string $indexName, array $keys, ?CreateQueryIndexOptions $options = null)
     {
         Extension\queryIndexCreate($this->core, $bucketName, $indexName, $keys, CreateQueryIndexOptions::export($options));
     }
@@ -84,7 +84,7 @@ class QueryIndexManager implements QueryIndexManagerInterface
      *
      * @since 4.0.0
      */
-    public function createPrimaryIndex(string $bucketName, CreateQueryPrimaryIndexOptions $options = null)
+    public function createPrimaryIndex(string $bucketName, ?CreateQueryPrimaryIndexOptions $options = null)
     {
         Extension\queryIndexCreatePrimary($this->core, $bucketName, CreateQueryPrimaryIndexOptions::export($options));
     }
@@ -98,7 +98,7 @@ class QueryIndexManager implements QueryIndexManagerInterface
      *
      * @since 4.0.0
      */
-    public function dropIndex(string $bucketName, string $indexName, DropQueryIndexOptions $options = null)
+    public function dropIndex(string $bucketName, string $indexName, ?DropQueryIndexOptions $options = null)
     {
         Extension\queryIndexDrop($this->core, $bucketName, $indexName, DropQueryIndexOptions::export($options));
     }
@@ -111,7 +111,7 @@ class QueryIndexManager implements QueryIndexManagerInterface
      *
      * @since 4.0.0
      */
-    public function dropPrimaryIndex(string $bucketName, DropQueryPrimaryIndexOptions $options = null)
+    public function dropPrimaryIndex(string $bucketName, ?DropQueryPrimaryIndexOptions $options = null)
     {
         Extension\queryIndexDropPrimary($this->core, $bucketName, DropQueryPrimaryIndexOptions::export($options));
     }
@@ -124,7 +124,7 @@ class QueryIndexManager implements QueryIndexManagerInterface
      *
      * @since 4.0.0
      */
-    public function buildDeferredIndexes(string $bucketName, BuildQueryIndexesOptions $options = null)
+    public function buildDeferredIndexes(string $bucketName, ?BuildQueryIndexesOptions $options = null)
     {
         Extension\queryIndexBuildDeferred($this->core, $bucketName, BuildQueryIndexesOptions::export($options));
     }
@@ -140,7 +140,7 @@ class QueryIndexManager implements QueryIndexManagerInterface
      * @throws UnambiguousTimeoutException
      * @since 4.0.0
      */
-    public function watchIndexes(string $bucketName, array $indexNames, int $timeoutMilliseconds, WatchQueryIndexesOptions $options = null)
+    public function watchIndexes(string $bucketName, array $indexNames, int $timeoutMilliseconds, ?WatchQueryIndexesOptions $options = null)
     {
         $exported = WatchQueryIndexesOptions::export($options);
         if (array_key_exists("watchPrimary", $exported) && $exported["watchPrimary"]) {

--- a/Couchbase/Management/QueryIndexManagerInterface.php
+++ b/Couchbase/Management/QueryIndexManagerInterface.php
@@ -1,20 +1,38 @@
 <?php
 
+/**
+ * Copyright 2014-Present Couchbase, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+declare(strict_types=1);
+
 namespace Couchbase\Management;
 
 interface QueryIndexManagerInterface
 {
-    public function getAllIndexes(string $bucketName, GetAllQueryIndexesOptions $options = null): array;
+    public function getAllIndexes(string $bucketName, ?GetAllQueryIndexesOptions $options = null): array;
 
-    public function createIndex(string $bucketName, string $indexName, array $fields, CreateQueryIndexOptions $options = null);
+    public function createIndex(string $bucketName, string $indexName, array $fields, ?CreateQueryIndexOptions $options = null);
 
-    public function createPrimaryIndex(string $bucketName, CreateQueryPrimaryIndexOptions $options = null);
+    public function createPrimaryIndex(string $bucketName, ?CreateQueryPrimaryIndexOptions $options = null);
 
-    public function dropIndex(string $bucketName, string $indexName, DropQueryIndexOptions $options = null);
+    public function dropIndex(string $bucketName, string $indexName, ?DropQueryIndexOptions $options = null);
 
-    public function dropPrimaryIndex(string $bucketName, DropQueryPrimaryIndexOptions $options = null);
+    public function dropPrimaryIndex(string $bucketName, ?DropQueryPrimaryIndexOptions $options = null);
 
-    public function buildDeferredIndexes(string $bucketName, BuildQueryIndexesOptions $options = null);
+    public function buildDeferredIndexes(string $bucketName, ?BuildQueryIndexesOptions $options = null);
 
-    public function watchIndexes(string $bucketName, array $indexNames, int $timeoutMilliseconds, WatchQueryIndexesOptions $options = null);
+    public function watchIndexes(string $bucketName, array $indexNames, int $timeoutMilliseconds, ?WatchQueryIndexesOptions $options = null);
 }

--- a/Couchbase/Management/ScopeSearchIndexManager.php
+++ b/Couchbase/Management/ScopeSearchIndexManager.php
@@ -44,7 +44,7 @@ class ScopeSearchIndexManager implements ScopeSearchIndexManagerInterface
      *
      * @since 4.1.7
      */
-    public function getIndex(string $indexName, GetSearchIndexOptions $options = null): SearchIndex
+    public function getIndex(string $indexName, ?GetSearchIndexOptions $options = null): SearchIndex
     {
         $result = Extension\scopeSearchIndexGet($this->core, $this->bucketName, $this->scopeName, $indexName, GetSearchIndexOptions::export($options));
 
@@ -59,7 +59,7 @@ class ScopeSearchIndexManager implements ScopeSearchIndexManagerInterface
      *
      * @since 4.1.7
      */
-    public function getAllIndexes(GetAllSearchIndexesOptions $options = null): array
+    public function getAllIndexes(?GetAllSearchIndexesOptions $options = null): array
     {
         $result = Extension\scopeSearchIndexGetAll($this->core, $this->bucketName, $this->scopeName, GetAllSearchIndexesOptions::export($options));
         $indexes = [];
@@ -77,7 +77,7 @@ class ScopeSearchIndexManager implements ScopeSearchIndexManagerInterface
      *
      * @since 4.1.7
      */
-    public function upsertIndex(SearchIndex $indexDefinition, UpsertSearchIndexOptions $options = null)
+    public function upsertIndex(SearchIndex $indexDefinition, ?UpsertSearchIndexOptions $options = null)
     {
         Extension\scopeSearchIndexUpsert($this->core, $this->bucketName, $this->scopeName, SearchIndex::export($indexDefinition), UpsertSearchIndexOptions::export($options));
     }
@@ -90,7 +90,7 @@ class ScopeSearchIndexManager implements ScopeSearchIndexManagerInterface
      *
      * @since 4.1.7
      */
-    public function dropIndex(string $name, DropSearchIndexOptions $options = null)
+    public function dropIndex(string $name, ?DropSearchIndexOptions $options = null)
     {
         Extension\scopeSearchIndexDrop($this->core, $this->bucketName, $this->scopeName, $name, DropSearchIndexOptions::export($options));
     }
@@ -104,7 +104,7 @@ class ScopeSearchIndexManager implements ScopeSearchIndexManagerInterface
      * @return int
      * @since 4.1.7
      */
-    public function getIndexedDocumentsCount(string $indexName, GetIndexedSearchIndexOptions $options = null): int
+    public function getIndexedDocumentsCount(string $indexName, ?GetIndexedSearchIndexOptions $options = null): int
     {
         $result = Extension\scopeSearchIndexGetDocumentsCount($this->core, $this->bucketName, $this->scopeName, $indexName, GetIndexedSearchIndexOptions::export($options));
         return $result['count'];
@@ -118,7 +118,7 @@ class ScopeSearchIndexManager implements ScopeSearchIndexManagerInterface
      *
      * @since 4.1.7
      */
-    public function pauseIngest(string $indexName, PauseIngestSearchIndexOptions $options = null)
+    public function pauseIngest(string $indexName, ?PauseIngestSearchIndexOptions $options = null)
     {
         Extension\scopeSearchIndexIngestPause($this->core, $this->bucketName, $this->scopeName, $indexName, PauseIngestSearchIndexOptions::export($options));
     }
@@ -131,7 +131,7 @@ class ScopeSearchIndexManager implements ScopeSearchIndexManagerInterface
      *
      * @since 4.1.7
      */
-    public function resumeIngest(string $indexName, ResumeIngestSearchIndexOptions $options = null)
+    public function resumeIngest(string $indexName, ?ResumeIngestSearchIndexOptions $options = null)
     {
         Extension\scopeSearchIndexIngestResume($this->core, $this->bucketName, $this->scopeName, $indexName, ResumeIngestSearchIndexOptions::export($options));
     }
@@ -144,7 +144,7 @@ class ScopeSearchIndexManager implements ScopeSearchIndexManagerInterface
      *
      * @since 4.1.7
      */
-    public function allowQuerying(string $indexName, AllowQueryingSearchIndexOptions $options = null)
+    public function allowQuerying(string $indexName, ?AllowQueryingSearchIndexOptions $options = null)
     {
         Extension\scopeSearchIndexQueryingAllow($this->core, $this->bucketName, $this->scopeName, $indexName, AllowQueryingSearchIndexOptions::export($options));
     }
@@ -157,7 +157,7 @@ class ScopeSearchIndexManager implements ScopeSearchIndexManagerInterface
      *
      * @since 4.1.7
      */
-    public function disallowQuerying(string $indexName, DisallowQueryingSearchIndexOptions $options = null)
+    public function disallowQuerying(string $indexName, ?DisallowQueryingSearchIndexOptions $options = null)
     {
         Extension\scopeSearchIndexQueryingDisallow($this->core, $this->bucketName, $this->scopeName, $indexName, DisallowQueryingSearchIndexOptions::export($options));
     }
@@ -170,7 +170,7 @@ class ScopeSearchIndexManager implements ScopeSearchIndexManagerInterface
      *
      * @since 4.1.7
      */
-    public function freezePlan(string $indexName, FreezePlanSearchIndexOptions $options = null)
+    public function freezePlan(string $indexName, ?FreezePlanSearchIndexOptions $options = null)
     {
         Extension\scopeSearchIndexPlanFreeze($this->core, $this->bucketName, $this->scopeName, $indexName, FreezePlanSearchIndexOptions::export($options));
     }
@@ -183,7 +183,7 @@ class ScopeSearchIndexManager implements ScopeSearchIndexManagerInterface
      *
      * @since 4.1.7
      */
-    public function unfreezePlan(string $indexName, UnfreezePlanSearchIndexOptions $options = null)
+    public function unfreezePlan(string $indexName, ?UnfreezePlanSearchIndexOptions $options = null)
     {
         Extension\scopeSearchIndexPlanUnfreeze($this->core, $this->bucketName, $this->scopeName, $indexName, UnfreezePlanSearchIndexOptions::export($options));
     }
@@ -198,7 +198,7 @@ class ScopeSearchIndexManager implements ScopeSearchIndexManagerInterface
      * @return array
      * @since 4.1.7
      */
-    public function analyzeDocument(string $indexName, $document, AnalyzeDocumentOptions $options = null): array
+    public function analyzeDocument(string $indexName, $document, ?AnalyzeDocumentOptions $options = null): array
     {
         $result = Extension\scopeSearchIndexDocumentAnalyze($this->core, $this->bucketName, $this->scopeName, $indexName, json_encode($document), AnalyzeDocumentOptions::export($options));
         return json_decode($result["analysis"], true);

--- a/Couchbase/Management/ScopeSearchIndexManagerInterface.php
+++ b/Couchbase/Management/ScopeSearchIndexManagerInterface.php
@@ -1,30 +1,48 @@
 <?php
 
+/**
+ * Copyright 2014-Present Couchbase, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+declare(strict_types=1);
+
 namespace Couchbase\Management;
 
 interface ScopeSearchIndexManagerInterface
 {
-    public function getIndex(string $indexName, GetSearchIndexOptions $options = null): SearchIndex;
+    public function getIndex(string $indexName, ?GetSearchIndexOptions $options = null): SearchIndex;
 
-    public function getAllIndexes(GetAllSearchIndexesOptions $options = null): array;
+    public function getAllIndexes(?GetAllSearchIndexesOptions $options = null): array;
 
-    public function upsertIndex(SearchIndex $indexDefinition, UpsertSearchIndexOptions $options = null);
+    public function upsertIndex(SearchIndex $indexDefinition, ?UpsertSearchIndexOptions $options = null);
 
-    public function dropIndex(string $name, DropSearchIndexOptions $options = null);
+    public function dropIndex(string $name, ?DropSearchIndexOptions $options = null);
 
-    public function getIndexedDocumentsCount(string $indexName, GetIndexedSearchIndexOptions $options = null): int;
+    public function getIndexedDocumentsCount(string $indexName, ?GetIndexedSearchIndexOptions $options = null): int;
 
-    public function pauseIngest(string $indexName, PauseIngestSearchIndexOptions $options = null);
+    public function pauseIngest(string $indexName, ?PauseIngestSearchIndexOptions $options = null);
 
-    public function resumeIngest(string $indexName, ResumeIngestSearchIndexOptions $options = null);
+    public function resumeIngest(string $indexName, ?ResumeIngestSearchIndexOptions $options = null);
 
-    public function allowQuerying(string $indexName, AllowQueryingSearchIndexOptions $options = null);
+    public function allowQuerying(string $indexName, ?AllowQueryingSearchIndexOptions $options = null);
 
-    public function disallowQuerying(string $indexName, DisallowQueryingSearchIndexOptions $options = null);
+    public function disallowQuerying(string $indexName, ?DisallowQueryingSearchIndexOptions $options = null);
 
-    public function freezePlan(string $indexName, FreezePlanSearchIndexOptions $options = null);
+    public function freezePlan(string $indexName, ?FreezePlanSearchIndexOptions $options = null);
 
-    public function unfreezePlan(string $indexName, UnfreezePlanSearchIndexOptions $options = null);
+    public function unfreezePlan(string $indexName, ?UnfreezePlanSearchIndexOptions $options = null);
 
-    public function analyzeDocument(string $indexName, $document, AnalyzeDocumentOptions $options = null): array;
+    public function analyzeDocument(string $indexName, $document, ?AnalyzeDocumentOptions $options = null): array;
 }

--- a/Couchbase/Management/SearchIndexManager.php
+++ b/Couchbase/Management/SearchIndexManager.php
@@ -51,7 +51,7 @@ class SearchIndexManager implements SearchIndexManagerInterface
      *
      * @since 4.1.5
      */
-    public function getIndex(string $indexName, GetSearchIndexOptions $options = null): SearchIndex
+    public function getIndex(string $indexName, ?GetSearchIndexOptions $options = null): SearchIndex
     {
         $result = Extension\searchIndexGet($this->core, $indexName, GetSearchIndexOptions::export($options));
 
@@ -66,7 +66,7 @@ class SearchIndexManager implements SearchIndexManagerInterface
      *
      * @since 4.1.5
      */
-    public function getAllIndexes(GetAllSearchIndexesOptions $options = null): array
+    public function getAllIndexes(?GetAllSearchIndexesOptions $options = null): array
     {
         $result = Extension\searchIndexGetAll($this->core, GetAllSearchIndexesOptions::export($options));
         $indexes = [];
@@ -84,7 +84,7 @@ class SearchIndexManager implements SearchIndexManagerInterface
      *
      * @since 4.1.5
      */
-    public function upsertIndex(SearchIndex $indexDefinition, UpsertSearchIndexOptions $options = null)
+    public function upsertIndex(SearchIndex $indexDefinition, ?UpsertSearchIndexOptions $options = null)
     {
         Extension\searchIndexUpsert($this->core, SearchIndex::export($indexDefinition), UpsertSearchIndexOptions::export($options));
     }
@@ -97,7 +97,7 @@ class SearchIndexManager implements SearchIndexManagerInterface
      *
      * @since 4.1.5
      */
-    public function dropIndex(string $name, DropSearchIndexOptions $options = null)
+    public function dropIndex(string $name, ?DropSearchIndexOptions $options = null)
     {
         Extension\searchIndexDrop($this->core, $name, DropSearchIndexOptions::export($options));
     }
@@ -111,7 +111,7 @@ class SearchIndexManager implements SearchIndexManagerInterface
      *
      * @since 4.1.5
      */
-    public function getIndexedDocumentsCount(string $indexName, GetIndexedSearchIndexOptions $options = null): int
+    public function getIndexedDocumentsCount(string $indexName, ?GetIndexedSearchIndexOptions $options = null): int
     {
         $result = Extension\searchIndexGetDocumentsCount($this->core, $indexName, GetIndexedSearchIndexOptions::export($options));
         return $result['count'];
@@ -125,7 +125,7 @@ class SearchIndexManager implements SearchIndexManagerInterface
      *
      * @since 4.1.5
      */
-    public function pauseIngest(string $indexName, PauseIngestSearchIndexOptions $options = null)
+    public function pauseIngest(string $indexName, ?PauseIngestSearchIndexOptions $options = null)
     {
         Extension\searchIndexIngestPause($this->core, $indexName, PauseIngestSearchIndexOptions::export($options));
     }
@@ -138,7 +138,7 @@ class SearchIndexManager implements SearchIndexManagerInterface
      *
      * @since 4.1.5
      */
-    public function resumeIngest(string $indexName, ResumeIngestSearchIndexOptions $options = null)
+    public function resumeIngest(string $indexName, ?ResumeIngestSearchIndexOptions $options = null)
     {
         Extension\searchIndexIngestResume($this->core, $indexName, ResumeIngestSearchIndexOptions::export($options));
     }
@@ -151,7 +151,7 @@ class SearchIndexManager implements SearchIndexManagerInterface
      *
      * @since 4.1.5
      */
-    public function allowQuerying(string $indexName, AllowQueryingSearchIndexOptions $options = null)
+    public function allowQuerying(string $indexName, ?AllowQueryingSearchIndexOptions $options = null)
     {
         Extension\searchIndexQueryingAllow($this->core, $indexName, AllowQueryingSearchIndexOptions::export($options));
     }
@@ -164,7 +164,7 @@ class SearchIndexManager implements SearchIndexManagerInterface
      *
      * @since 4.1.5
      */
-    public function disallowQuerying(string $indexName, DisallowQueryingSearchIndexOptions $options = null)
+    public function disallowQuerying(string $indexName, ?DisallowQueryingSearchIndexOptions $options = null)
     {
         Extension\searchIndexQueryingDisallow($this->core, $indexName, DisallowQueryingSearchIndexOptions::export($options));
     }
@@ -177,7 +177,7 @@ class SearchIndexManager implements SearchIndexManagerInterface
      *
      * @since 4.1.5
      */
-    public function freezePlan(string $indexName, FreezePlanSearchIndexOptions $options = null)
+    public function freezePlan(string $indexName, ?FreezePlanSearchIndexOptions $options = null)
     {
         Extension\searchIndexPlanFreeze($this->core, $indexName, FreezePlanSearchIndexOptions::export($options));
     }
@@ -189,7 +189,7 @@ class SearchIndexManager implements SearchIndexManagerInterface
      *
      * @since 4.1.5
      */
-    public function unfreezePlan(string $indexName, UnfreezePlanSearchIndexOptions $options = null)
+    public function unfreezePlan(string $indexName, ?UnfreezePlanSearchIndexOptions $options = null)
     {
         Extension\searchIndexPlanUnfreeze($this->core, $indexName, UnfreezePlanSearchIndexOptions::export($options));
     }
@@ -204,7 +204,7 @@ class SearchIndexManager implements SearchIndexManagerInterface
      *
      * @since 4.1.5
      */
-    public function analyzeDocument(string $indexName, $document, AnalyzeDocumentOptions $options = null): array
+    public function analyzeDocument(string $indexName, $document, ?AnalyzeDocumentOptions $options = null): array
     {
         $result = Extension\searchIndexDocumentAnalyze($this->core, $indexName, json_encode($document), AnalyzeDocumentOptions::export($options));
         return json_decode($result["analysis"], true);

--- a/Couchbase/Management/SearchIndexManagerInterface.php
+++ b/Couchbase/Management/SearchIndexManagerInterface.php
@@ -1,30 +1,46 @@
 <?php
 
+/**
+ * Copyright 2014-Present Couchbase, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 namespace Couchbase\Management;
 
 interface SearchIndexManagerInterface
 {
-    public function getIndex(string $indexName, GetSearchIndexOptions $options = null): SearchIndex;
+    public function getIndex(string $indexName, ?GetSearchIndexOptions $options = null): SearchIndex;
 
-    public function getAllIndexes(GetAllSearchIndexesOptions $options = null): array;
+    public function getAllIndexes(?GetAllSearchIndexesOptions $options = null): array;
 
-    public function upsertIndex(SearchIndex $indexDefinition, UpsertSearchIndexOptions $options = null);
+    public function upsertIndex(SearchIndex $indexDefinition, ?UpsertSearchIndexOptions $options = null);
 
-    public function dropIndex(string $name, DropSearchIndexOptions $options = null);
+    public function dropIndex(string $name, ?DropSearchIndexOptions $options = null);
 
-    public function getIndexedDocumentsCount(string $indexName, GetIndexedSearchIndexOptions $options = null): int;
+    public function getIndexedDocumentsCount(string $indexName, ?GetIndexedSearchIndexOptions $options = null): int;
 
-    public function pauseIngest(string $indexName, PauseIngestSearchIndexOptions $options = null);
+    public function pauseIngest(string $indexName, ?PauseIngestSearchIndexOptions $options = null);
 
-    public function resumeIngest(string $indexName, ResumeIngestSearchIndexOptions $options = null);
+    public function resumeIngest(string $indexName, ?ResumeIngestSearchIndexOptions $options = null);
 
-    public function allowQuerying(string $indexName, AllowQueryingSearchIndexOptions $options = null);
+    public function allowQuerying(string $indexName, ?AllowQueryingSearchIndexOptions $options = null);
 
-    public function disallowQuerying(string $indexName, DisallowQueryingSearchIndexOptions $options = null);
+    public function disallowQuerying(string $indexName, ?DisallowQueryingSearchIndexOptions $options = null);
 
-    public function freezePlan(string $indexName, FreezePlanSearchIndexOptions $options = null);
+    public function freezePlan(string $indexName, ?FreezePlanSearchIndexOptions $options = null);
 
-    public function unfreezePlan(string $indexName, UnfreezePlanSearchIndexOptions $options = null);
+    public function unfreezePlan(string $indexName, ?UnfreezePlanSearchIndexOptions $options = null);
 
-    public function analyzeDocument(string $indexName, $document, AnalyzeDocumentOptions $options = null): array;
+    public function analyzeDocument(string $indexName, $document, ?AnalyzeDocumentOptions $options = null): array;
 }

--- a/Couchbase/Management/UpdateCollectionSettings.php
+++ b/Couchbase/Management/UpdateCollectionSettings.php
@@ -30,7 +30,7 @@ class UpdateCollectionSettings
     /**
      * @throws InvalidArgumentException
      */
-    public function __construct(int $maxExpiry = null, bool $history = null)
+    public function __construct(?int $maxExpiry = null, ?bool $history = null)
     {
         if ($maxExpiry && $maxExpiry < -1) {
             throw new InvalidArgumentException("Collection max expiry must be greater than or equal to -1.");
@@ -42,7 +42,7 @@ class UpdateCollectionSettings
     /**
      * @throws InvalidArgumentException
      */
-    public static function build(int $maxExpiry = null, bool $history = null): UpdateCollectionSettings
+    public static function build(?int $maxExpiry = null, ?bool $history = null): UpdateCollectionSettings
     {
         return new UpdateCollectionSettings($maxExpiry, $history);
     }

--- a/Couchbase/Management/UserManager.php
+++ b/Couchbase/Management/UserManager.php
@@ -47,7 +47,7 @@ class UserManager implements UserManagerInterface
      * @return UserAndMetadata
      * @since 4.0.0
      */
-    public function getUser(string $name, GetUserOptions $options = null): UserAndMetadata
+    public function getUser(string $name, ?GetUserOptions $options = null): UserAndMetadata
     {
         $result = Extension\userGet($this->core, $name, GetUserOptions::export($options));
         return UserAndMetadata::import($result);
@@ -60,7 +60,7 @@ class UserManager implements UserManagerInterface
      * @return array
      * @since 4.0.0
      */
-    public function getAllUsers(GetAllUsersOptions $options = null): array
+    public function getAllUsers(?GetAllUsersOptions $options = null): array
     {
         $result = Extension\userGetAll($this->core, GetAllUsersOptions::export($options));
         $users = [];
@@ -78,7 +78,7 @@ class UserManager implements UserManagerInterface
      * @param UpsertUserOptions|null $options the options to use when upserting the user.
      * @since 4.0.0
      */
-    public function upsertUser(User $user, UpsertUserOptions $options = null)
+    public function upsertUser(User $user, ?UpsertUserOptions $options = null)
     {
         Extension\userUpsert($this->core, User::export($user), UpsertUserOptions::export($options));
     }
@@ -90,7 +90,7 @@ class UserManager implements UserManagerInterface
      * @param DropUserOptions|null $options the options to use when dropping the user.
      * @since 4.0.0
      */
-    public function dropUser(string $name, DropUserOptions $options = null)
+    public function dropUser(string $name, ?DropUserOptions $options = null)
     {
         Extension\userDrop($this->core, $name, DropUserOptions::export($options));
     }
@@ -103,7 +103,7 @@ class UserManager implements UserManagerInterface
      * @see \Couchbase\Management\RoleAndDescription
      * @since 4.0.0
      */
-    public function getRoles(GetRolesOptions $options = null): array
+    public function getRoles(?GetRolesOptions $options = null): array
     {
         $result = Extension\roleGetAll($this->core, GetRolesOptions::export($options));
         foreach ($result as $role) {
@@ -121,7 +121,7 @@ class UserManager implements UserManagerInterface
      * @return Group
      * @since 4.0.0
      */
-    public function getGroup(string $name, GetGroupOptions $options = null): Group
+    public function getGroup(string $name, ?GetGroupOptions $options = null): Group
     {
         $result = Extension\groupGet($this->core, $name, GetGroupOptions::export($options));
         return Group::import($result);
@@ -135,7 +135,7 @@ class UserManager implements UserManagerInterface
      * @see \Couchbase\Management\Group
      * @since 4.0.0
      */
-    public function getAllGroups(GetAllGroupsOptions $options = null): array
+    public function getAllGroups(?GetAllGroupsOptions $options = null): array
     {
         $result = Extension\groupGetAll($this->core, GetAllGroupsOptions::export($options));
         $groups = [];
@@ -153,7 +153,7 @@ class UserManager implements UserManagerInterface
      * @param UpsertGroupOptions|null $options the options to use when upserting the group.
      * @since 4.0.0
      */
-    public function upsertGroup(Group $group, UpsertGroupOptions $options = null)
+    public function upsertGroup(Group $group, ?UpsertGroupOptions $options = null)
     {
         Extension\groupUpsert($this->core, Group::export($group), UpsertGroupOptions::export($options));
     }
@@ -165,7 +165,7 @@ class UserManager implements UserManagerInterface
      * @param DropGroupOptions|null $options the options to use when dropping the group.
      * @since 4.0.0
      */
-    public function dropGroup(string $name, DropGroupOptions $options = null)
+    public function dropGroup(string $name, ?DropGroupOptions $options = null)
     {
         Extension\groupDrop($this->core, $name, DropGroupOptions::export($options));
     }
@@ -176,7 +176,7 @@ class UserManager implements UserManagerInterface
      * @param ChangePasswordOptions|null $options the options to use when changing the password of the user
      * @since 4.1.1
      */
-    public function changePassword(string $newPassword, ChangePasswordOptions $options = null)
+    public function changePassword(string $newPassword, ?ChangePasswordOptions $options = null)
     {
         Extension\passwordChange($this->core, $newPassword, ChangePasswordOptions::export($options));
     }

--- a/Couchbase/Management/UserManagerInterface.php
+++ b/Couchbase/Management/UserManagerInterface.php
@@ -1,26 +1,44 @@
 <?php
 
+/*
+ * Copyright 2022-Present Couchbase, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+declare(strict_types=1);
+
 namespace Couchbase\Management;
 
 interface UserManagerInterface
 {
-    public function getUser(string $name, GetUserOptions $options = null): UserAndMetadata;
+    public function getUser(string $name, ?GetUserOptions $options = null): UserAndMetadata;
 
-    public function getAllUsers(GetAllUsersOptions $options = null): array;
+    public function getAllUsers(?GetAllUsersOptions $options = null): array;
 
-    public function upsertUser(User $user, UpsertUserOptions $options = null);
+    public function upsertUser(User $user, ?UpsertUserOptions $options = null);
 
-    public function dropUser(string $name, DropUserOptions $options = null);
+    public function dropUser(string $name, ?DropUserOptions $options = null);
 
-    public function getRoles(GetRolesOptions $options = null): array;
+    public function getRoles(?GetRolesOptions $options = null): array;
 
-    public function getGroup(string $name, GetGroupOptions $options = null): Group;
+    public function getGroup(string $name, ?GetGroupOptions $options = null): Group;
 
-    public function getAllGroups(GetAllGroupsOptions $options = null): array;
+    public function getAllGroups(?GetAllGroupsOptions $options = null): array;
 
-    public function upsertGroup(Group $group, UpsertGroupOptions $options = null);
+    public function upsertGroup(Group $group, ?UpsertGroupOptions $options = null);
 
-    public function dropGroup(string $name, DropGroupOptions $options = null);
+    public function dropGroup(string $name, ?DropGroupOptions $options = null);
 
-    public function changePassword(string $newPassword, ChangePasswordOptions $options = null);
+    public function changePassword(string $newPassword, ?ChangePasswordOptions $options = null);
 }

--- a/Couchbase/NoopTracer.php
+++ b/Couchbase/NoopTracer.php
@@ -28,7 +28,7 @@ namespace Couchbase;
  */
 class NoopTracer implements RequestTracer
 {
-    public function requestSpan(string $name, RequestSpan $parent = null)
+    public function requestSpan(string $name, ?RequestSpan $parent = null)
     {
     }
 }

--- a/Couchbase/NumericRangeSearchFacet.php
+++ b/Couchbase/NumericRangeSearchFacet.php
@@ -46,7 +46,7 @@ class NumericRangeSearchFacet implements JsonSerializable, SearchFacet
      * @return NumericRangeSearchFacet
      * @since 4.0.0
      */
-    public function addRange(string $name, float $min = null, float $max = null): NumericRangeSearchFacet
+    public function addRange(string $name, ?float $min = null, ?float $max = null): NumericRangeSearchFacet
     {
         $range = [
             'name' => $name,

--- a/Couchbase/Protostellar/BinaryCollection.php
+++ b/Couchbase/Protostellar/BinaryCollection.php
@@ -65,7 +65,7 @@ class BinaryCollection implements BinaryCollectionInterface
     /**
      * @throws InvalidArgumentException
      */
-    public function append(string $key, string $value, AppendOptions $options = null): MutationResult
+    public function append(string $key, string $value, ?AppendOptions $options = null): MutationResult
     {
         $exportedOptions = AppendOptions::export($options);
         $request = RequestFactory::makeRequest(
@@ -83,7 +83,7 @@ class BinaryCollection implements BinaryCollectionInterface
     /**
      * @throws InvalidArgumentException
      */
-    public function prepend(string $key, string $value, PrependOptions $options = null): MutationResult
+    public function prepend(string $key, string $value, ?PrependOptions $options = null): MutationResult
     {
         $exportedOptions = PrependOptions::export($options);
         $request = RequestFactory::makeRequest(
@@ -101,7 +101,7 @@ class BinaryCollection implements BinaryCollectionInterface
     /**
      * @throws InvalidArgumentException
      */
-    public function increment(string $key, IncrementOptions $options = null): CounterResult
+    public function increment(string $key, ?IncrementOptions $options = null): CounterResult
     {
         $exportedOptions = IncrementOptions::export($options);
         $request = RequestFactory::makeRequest(
@@ -119,7 +119,7 @@ class BinaryCollection implements BinaryCollectionInterface
     /**
      * @throws InvalidArgumentException
      */
-    public function decrement(string $key, DecrementOptions $options = null): CounterResult
+    public function decrement(string $key, ?DecrementOptions $options = null): CounterResult
     {
         $exportedOptions = DecrementOptions::export($options);
         $request = RequestFactory::makeRequest(

--- a/Couchbase/Protostellar/Bucket.php
+++ b/Couchbase/Protostellar/Bucket.php
@@ -66,7 +66,7 @@ class Bucket implements BucketInterface
     /**
      * @throws UnsupportedOperationException
      */
-    public function viewQuery(string $designDoc, string $viewName, ViewOptions $options = null): ViewResult
+    public function viewQuery(string $designDoc, string $viewName, ?ViewOptions $options = null): ViewResult
     {
         throw new UnsupportedOperationException("Views are not supported in CNG");
     }

--- a/Couchbase/Protostellar/Cluster.php
+++ b/Couchbase/Protostellar/Cluster.php
@@ -65,7 +65,7 @@ class Cluster implements ClusterInterface
     /**
      * @throws InvalidArgumentException
      */
-    public function query(string $statement, QueryOptions $options = null): QueryResult
+    public function query(string $statement, ?QueryOptions $options = null): QueryResult
     {
         $exportedOptions = QueryOptions::export($options);
         $request = RequestFactory::makeRequest(
@@ -81,7 +81,7 @@ class Cluster implements ClusterInterface
         return new QueryResult($finalArray, QueryOptions::getTranscoder($options));
     }
 
-    public function analyticsQuery(string $statement, AnalyticsOptions $options = null): AnalyticsResult
+    public function analyticsQuery(string $statement, ?AnalyticsOptions $options = null): AnalyticsResult
     {
         $exportedOptions = AnalyticsOptions::export($options);
         $request = RequestFactory::makeRequest(
@@ -100,7 +100,7 @@ class Cluster implements ClusterInterface
     /**
      * @throws InvalidArgumentException
      */
-    public function searchQuery(string $indexName, SearchQuery $query, SearchOptions $options = null): SearchResult
+    public function searchQuery(string $indexName, SearchQuery $query, ?SearchOptions $options = null): SearchResult
     {
         $exportedOptions = SearchOptions::export($options);
         $request = RequestFactory::makeRequest(

--- a/Couchbase/Protostellar/Collection.php
+++ b/Couchbase/Protostellar/Collection.php
@@ -80,7 +80,7 @@ class Collection implements CollectionInterface
     /**
      * @throws InvalidArgumentException
      */
-    public function upsert(string $key, $document, UpsertOptions $options = null): MutationResult
+    public function upsert(string $key, $document, ?UpsertOptions $options = null): MutationResult
     {
         $exportedOptions = UpsertOptions::export($options);
         $request = RequestFactory::makeRequest(
@@ -98,7 +98,7 @@ class Collection implements CollectionInterface
     /**
      * @throws InvalidArgumentException|DecodingFailureException
      */
-    public function insert(string $key, $document, InsertOptions $options = null): MutationResult
+    public function insert(string $key, $document, ?InsertOptions $options = null): MutationResult
     {
         $exportedOptions = InsertOptions::export($options);
         $request = RequestFactory::makeRequest(
@@ -116,7 +116,7 @@ class Collection implements CollectionInterface
     /**
      * @throws InvalidArgumentException
      */
-    public function replace(string $key, $document, ReplaceOptions $options = null): MutationResult
+    public function replace(string $key, $document, ?ReplaceOptions $options = null): MutationResult
     {
         $exportedOptions = ReplaceOptions::export($options);
         $request = RequestFactory::makeRequest(
@@ -134,7 +134,7 @@ class Collection implements CollectionInterface
     /**
      * @throws InvalidArgumentException
      */
-    public function remove(string $key, RemoveOptions $options = null): MutationResult
+    public function remove(string $key, ?RemoveOptions $options = null): MutationResult
     {
         $exportedOptions = RemoveOptions::export($options);
         $request = RequestFactory::makeRequest(
@@ -149,7 +149,7 @@ class Collection implements CollectionInterface
         return KVResponseConverter::convertMutationResult($key, $res);
     }
 
-    public function get(string $key, GetOptions $options = null): GetResult
+    public function get(string $key, ?GetOptions $options = null): GetResult
     {
         $exportedOptions = GetOptions::export($options);
         $request = RequestFactory::makeRequest(
@@ -164,7 +164,7 @@ class Collection implements CollectionInterface
         return KVResponseConverter::convertGetResult($key, $res, $options);
     }
 
-    public function exists(string $key, ExistsOptions $options = null): ExistsResult
+    public function exists(string $key, ?ExistsOptions $options = null): ExistsResult
     {
         $exportedOptions = ExistsOptions::export($options);
         $request = RequestFactory::makeRequest(
@@ -183,7 +183,7 @@ class Collection implements CollectionInterface
      * @throws ProtocolException
      * @throws InvalidArgumentException
      */
-    public function getAndTouch(string $key, $expiry, GetAndTouchOptions $options = null): GetResult
+    public function getAndTouch(string $key, $expiry, ?GetAndTouchOptions $options = null): GetResult
     {
         $exportedOptions = GetAndTouchOptions::export($options);
         $request = RequestFactory::makeRequest(
@@ -202,7 +202,7 @@ class Collection implements CollectionInterface
      * @throws ProtocolException
      * @throws InvalidArgumentException
      */
-    public function getAndLock(string $key, int $lockTimeSeconds, GetAndLockOptions $options = null): GetResult
+    public function getAndLock(string $key, int $lockTimeSeconds, ?GetAndLockOptions $options = null): GetResult
     {
         $exportedOptions = GetAndLockOptions::export($options);
         $request = RequestFactory::makeRequest(
@@ -220,7 +220,7 @@ class Collection implements CollectionInterface
     /**
      * @throws ProtocolException
      */
-    public function unlock(string $key, string $cas, UnlockOptions $options = null): Result
+    public function unlock(string $key, string $cas, ?UnlockOptions $options = null): Result
     {
         $exportedOptions = UnlockOptions::export($options);
         $request = RequestFactory::makeRequest(
@@ -235,7 +235,7 @@ class Collection implements CollectionInterface
         return KVResponseConverter::convertUnlockResult($key, $cas);
     }
 
-    public function touch(string $key, $expiry, TouchOptions $options = null): MutationResult
+    public function touch(string $key, $expiry, ?TouchOptions $options = null): MutationResult
     {
         $exportedOptions = TouchOptions::export($options);
         $request = RequestFactory::makeRequest(
@@ -250,7 +250,7 @@ class Collection implements CollectionInterface
         return KVResponseConverter::convertTouchResult($key, $res);
     }
 
-    public function lookupIn(string $key, array $specs, LookupInOptions $options = null): LookupInResult
+    public function lookupIn(string $key, array $specs, ?LookupInOptions $options = null): LookupInResult
     {
         $exportedOptions = LookupInOptions::export($options);
         [$request, $order] = RequestFactory::makeRequest(
@@ -268,7 +268,7 @@ class Collection implements CollectionInterface
     /**
      * @throws InvalidArgumentException
      */
-    public function mutateIn(string $key, array $specs, MutateInOptions $options = null): MutateInResult
+    public function mutateIn(string $key, array $specs, ?MutateInOptions $options = null): MutateInResult
     {
         $exportedOptions = MutateInOptions::export($options);
         [$request, $order] = RequestFactory::makeRequest(
@@ -286,7 +286,7 @@ class Collection implements CollectionInterface
     /**
      * @throws DocumentIrretrievableException
      */
-    public function getAnyReplica(string $key, GetAnyReplicaOptions $options = null): GetReplicaResult
+    public function getAnyReplica(string $key, ?GetAnyReplicaOptions $options = null): GetReplicaResult
     {
         $exportedOptions = GetAnyReplicaOptions::export($options);
         $request = RequestFactory::makeRequest(
@@ -304,7 +304,7 @@ class Collection implements CollectionInterface
     /**
      * @throws DocumentNotFoundException
      */
-    public function getAllReplicas(string $key, GetAllReplicasOptions $options = null): array
+    public function getAllReplicas(string $key, ?GetAllReplicasOptions $options = null): array
     {
         $exportedOptions = GetAllReplicasOptions::export($options);
         $request = RequestFactory::makeRequest(

--- a/Couchbase/Protostellar/Internal/KV/KVRequestConverter.php
+++ b/Couchbase/Protostellar/Internal/KV/KVRequestConverter.php
@@ -1,5 +1,23 @@
 <?php
 
+/**
+ * Copyright 2014-Present Couchbase, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+declare(strict_types=1);
+
 namespace Couchbase\Protostellar\Internal\KV;
 
 use Couchbase\Exception\InvalidArgumentException;
@@ -51,7 +69,7 @@ class KVRequestConverter
     /**
      * @throws InvalidArgumentException
      */
-    public static function getUpsertRequest(string $key, $document, array $location, UpsertOptions $options = null): UpsertRequest
+    public static function getUpsertRequest(string $key, $document, array $location, ?UpsertOptions $options = null): UpsertRequest
     {
         [$encodedDocument, $contentType] = UpsertOptions::encodeDocument($options, $document);
         $exportedOptions = UpsertOptions::export($options);
@@ -79,7 +97,7 @@ class KVRequestConverter
     /**
      * @throws InvalidArgumentException
      */
-    public static function getInsertRequest(string $key, $document, array $location, InsertOptions $options = null): InsertRequest
+    public static function getInsertRequest(string $key, $document, array $location, ?InsertOptions $options = null): InsertRequest
     {
         [$encodedDocument, $contentType] = InsertOptions::encodeDocument($options, $document);
         $exportedOptions = InsertOptions::export($options);
@@ -104,7 +122,7 @@ class KVRequestConverter
     /**
      * @throws InvalidArgumentException
      */
-    public static function getReplaceRequest(string $key, $document, array $location, ReplaceOptions $options = null): ReplaceRequest
+    public static function getReplaceRequest(string $key, $document, array $location, ?ReplaceOptions $options = null): ReplaceRequest
     {
         [$encodedDocument, $contentType] = ReplaceOptions::encodeDocument($options, $document);
         $exportedOptions = ReplaceOptions::export($options);
@@ -220,7 +238,7 @@ class KVRequestConverter
         return new TouchRequest($request);
     }
 
-    public static function getLookupInRequest(string $key, array $specs, array $location, LookupInOptions $options = null): array
+    public static function getLookupInRequest(string $key, array $specs, array $location, ?LookupInOptions $options = null): array
     {
         $exportedOptions = LookupInOptions::export($options);
         $encoded = array_map(
@@ -247,7 +265,7 @@ class KVRequestConverter
     /**
      * @throws InvalidArgumentException
      */
-    public static function getMutateInRequest(string $key, array $specs, array $location, MutateInOptions $options = null): array
+    public static function getMutateInRequest(string $key, array $specs, array $location, ?MutateInOptions $options = null): array
     {
         $exportedOptions = MutateInOptions::export($options);
         $encoded = array_map(

--- a/Couchbase/Protostellar/Internal/KV/KVResponseConverter.php
+++ b/Couchbase/Protostellar/Internal/KV/KVResponseConverter.php
@@ -1,5 +1,21 @@
 <?php
 
+/**
+ * Copyright 2014-Present Couchbase, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 namespace Couchbase\Protostellar\Internal\KV;
 
 use Couchbase\CounterResult;
@@ -54,7 +70,7 @@ class KVResponseConverter
     /**
      * @throws DecodingFailureException
      */
-    public static function convertGetResult(string $key, GetResponse $result, GetOptions $options = null): GetResult
+    public static function convertGetResult(string $key, GetResponse $result, ?GetOptions $options = null): GetResult
     {
         return new GetResult(
             [
@@ -85,7 +101,7 @@ class KVResponseConverter
     /**
      * @throws DecodingFailureException
      */
-    public static function convertGetAndTouchResult(string $key, GetAndTouchResponse $result, GetAndTouchOptions $options = null): GetResult
+    public static function convertGetAndTouchResult(string $key, GetAndTouchResponse $result, ?GetAndTouchOptions $options = null): GetResult
     {
         return new GetResult(
             [
@@ -102,7 +118,7 @@ class KVResponseConverter
     /**
      * @throws DecodingFailureException
      */
-    public static function convertGetAndLockResult(string $key, GetAndLockResponse $result, GetAndLockOptions $options = null): GetResult
+    public static function convertGetAndLockResult(string $key, GetAndLockResponse $result, ?GetAndLockOptions $options = null): GetResult
     {
         return new GetResult(
             [
@@ -193,7 +209,7 @@ class KVResponseConverter
     /**
      * @throws DocumentIrretrievableException
      */
-    public static function convertGetAnyReplicaResult(string $key, array $response, GetAnyReplicaOptions $options = null): array
+    public static function convertGetAnyReplicaResult(string $key, array $response, ?GetAnyReplicaOptions $options = null): array
     {
         if (count($response) == 0) {
             throw new DocumentIrretrievableException(sprintf("Document %s was not found", $key));
@@ -204,7 +220,7 @@ class KVResponseConverter
     /**
      * @throws DocumentNotFoundException
      */
-    public static function convertGetAllReplicasResult(string $key, array $response, GetAllReplicasOptions $options = null): array
+    public static function convertGetAllReplicasResult(string $key, array $response, ?GetAllReplicasOptions $options = null): array
     {
         if (count($response) == 0) {
             throw new DocumentNotFoundException(sprintf("Document %s was not found", $key));

--- a/Couchbase/Protostellar/Internal/Management/CollectionManagementRequestConverter.php
+++ b/Couchbase/Protostellar/Internal/Management/CollectionManagementRequestConverter.php
@@ -33,7 +33,7 @@ class CollectionManagementRequestConverter
     /**
      * @throws InvalidArgumentException
      */
-    public static function getCreateCollectionRequest(string $bucketName, string $scopeName, string $collectionName, CreateCollectionSettings $settings = null): CreateCollectionRequest
+    public static function getCreateCollectionRequest(string $bucketName, string $scopeName, string $collectionName, ?CreateCollectionSettings $settings = null): CreateCollectionRequest
     {
         $exportedSettings = CreateCollectionSettings::export($settings);
         $request = [

--- a/Couchbase/Protostellar/Internal/Management/SearchIndexManagementRequestConverter.php
+++ b/Couchbase/Protostellar/Internal/Management/SearchIndexManagementRequestConverter.php
@@ -37,7 +37,7 @@ use Couchbase\Protostellar\Generated\Admin\Search\V1\UpdateIndexRequest;
 
 class SearchIndexManagementRequestConverter
 {
-    public static function getGetIndexRequest(string $indexName, string $bucketName = null, string $scopeName = null): GetIndexRequest
+    public static function getGetIndexRequest(string $indexName, ?string $bucketName = null, ?string $scopeName = null): GetIndexRequest
     {
         $request = [
             'name' => $indexName
@@ -51,7 +51,7 @@ class SearchIndexManagementRequestConverter
         return new GetIndexRequest($request);
     }
 
-    public static function getGetAllIndexesRequest(string $bucketName = null, string $scopeName = null): ListIndexesRequest
+    public static function getGetAllIndexesRequest(?string $bucketName = null, ?string $scopeName = null): ListIndexesRequest
     {
         $request = [];
         if (!is_null($bucketName)) {
@@ -63,7 +63,7 @@ class SearchIndexManagementRequestConverter
         return new ListIndexesRequest($request);
     }
 
-    public static function getCreateIndexRequest(array $index, string $bucketName = null, string $scopeName = null): CreateIndexRequest
+    public static function getCreateIndexRequest(array $index, ?string $bucketName = null, ?string $scopeName = null): CreateIndexRequest
     {
         $request = [
             "name" => $index["name"],
@@ -92,7 +92,7 @@ class SearchIndexManagementRequestConverter
         return new CreateIndexRequest($request);
     }
 
-    public static function getUpdateIndexRequest(array $index, string $bucketName = null, string $scopeName = null): UpdateIndexRequest
+    public static function getUpdateIndexRequest(array $index, ?string $bucketName = null, ?string $scopeName = null): UpdateIndexRequest
     {
         $request = [
             "index" => self::getIndex($index)
@@ -106,7 +106,7 @@ class SearchIndexManagementRequestConverter
         return new UpdateIndexRequest($request);
     }
 
-    public static function getDropIndexRequest(string $indexName, string $bucketName = null, string $scopeName = null): DeleteIndexRequest
+    public static function getDropIndexRequest(string $indexName, ?string $bucketName = null, ?string $scopeName = null): DeleteIndexRequest
     {
         $request = [
             "name" => $indexName
@@ -120,7 +120,7 @@ class SearchIndexManagementRequestConverter
         return new DeleteIndexRequest($request);
     }
 
-    public static function getGetIndexedDocumentCountRequest(string $indexName, string $bucketName = null, string $scopeName = null): GetIndexedDocumentsCountRequest
+    public static function getGetIndexedDocumentCountRequest(string $indexName, ?string $bucketName = null, ?string $scopeName = null): GetIndexedDocumentsCountRequest
     {
         $request = [
             "name" => $indexName
@@ -134,7 +134,7 @@ class SearchIndexManagementRequestConverter
         return new GetIndexedDocumentsCountRequest($request);
     }
 
-    public static function getPauseIngestRequest(string $indexName, string $bucketName = null, string $scopeName = null): PauseIndexIngestRequest
+    public static function getPauseIngestRequest(string $indexName, ?string $bucketName = null, ?string $scopeName = null): PauseIndexIngestRequest
     {
         $request = [
             "name" => $indexName
@@ -148,7 +148,7 @@ class SearchIndexManagementRequestConverter
         return new PauseIndexIngestRequest($request);
     }
 
-    public static function getResumeIngestRequest(string $indexName, string $bucketName = null, string $scopeName = null): ResumeIndexIngestRequest
+    public static function getResumeIngestRequest(string $indexName, ?string $bucketName = null, ?string $scopeName = null): ResumeIndexIngestRequest
     {
         $request = [
             "name" => $indexName
@@ -162,7 +162,7 @@ class SearchIndexManagementRequestConverter
         return new ResumeIndexIngestRequest($request);
     }
 
-    public static function getAllowQueryingRequest(string $indexName, string $bucketName = null, string $scopeName = null): AllowIndexQueryingRequest
+    public static function getAllowQueryingRequest(string $indexName, ?string $bucketName = null, ?string $scopeName = null): AllowIndexQueryingRequest
     {
         $request = [
             "name" => $indexName
@@ -176,7 +176,7 @@ class SearchIndexManagementRequestConverter
         return new AllowIndexQueryingRequest($request);
     }
 
-    public static function getDisallowQueryingRequest(string $indexName, string $bucketName = null, string $scopeName = null): DisallowIndexQueryingRequest
+    public static function getDisallowQueryingRequest(string $indexName, ?string $bucketName = null, ?string $scopeName = null): DisallowIndexQueryingRequest
     {
         $request = [
             "name" => $indexName
@@ -190,7 +190,7 @@ class SearchIndexManagementRequestConverter
         return new DisallowIndexQueryingRequest($request);
     }
 
-    public static function getFreezePlanRequest(string $indexName, string $bucketName = null, string $scopeName = null): FreezeIndexPlanRequest
+    public static function getFreezePlanRequest(string $indexName, ?string $bucketName = null, ?string $scopeName = null): FreezeIndexPlanRequest
     {
         $request = [
             "name" => $indexName
@@ -204,7 +204,7 @@ class SearchIndexManagementRequestConverter
         return new FreezeIndexPlanRequest($request);
     }
 
-    public static function getUnfreezePlanRequest(string $indexName, string $bucketName = null, string $scopeName = null): UnfreezeIndexPlanRequest
+    public static function getUnfreezePlanRequest(string $indexName, ?string $bucketName = null, ?string $scopeName = null): UnfreezeIndexPlanRequest
     {
         $request = [
             "name" => $indexName
@@ -218,7 +218,7 @@ class SearchIndexManagementRequestConverter
         return new UnfreezeIndexPlanRequest($request);
     }
 
-    public static function getAnalyzeDocumentRequest(string $indexName, $document, string $bucketName = null, string $scopeName = null): AnalyzeDocumentRequest
+    public static function getAnalyzeDocumentRequest(string $indexName, $document, ?string $bucketName = null, ?string $scopeName = null): AnalyzeDocumentRequest
     {
         $request = [
             "name" => $indexName,

--- a/Couchbase/Protostellar/Management/BucketManager.php
+++ b/Couchbase/Protostellar/Management/BucketManager.php
@@ -52,7 +52,7 @@ class BucketManager implements BucketManagerInterface
     /**
      * @throws InvalidArgumentException
      */
-    public function createBucket(BucketSettings $settings, CreateBucketOptions $options = null)
+    public function createBucket(BucketSettings $settings, ?CreateBucketOptions $options = null)
     {
         $exportedSettings = BucketSettings::export($settings);
         $exportedOptions = CreateBucketOptions::export($options);
@@ -70,7 +70,7 @@ class BucketManager implements BucketManagerInterface
     /**
      * @throws InvalidArgumentException
      */
-    public function updateBucket(BucketSettings $settings, UpdateBucketOptions $options = null)
+    public function updateBucket(BucketSettings $settings, ?UpdateBucketOptions $options = null)
     {
         $exportedSettings = BucketSettings::export($settings);
         $exportedOptions = UpdateBucketOptions::export($options);
@@ -85,7 +85,7 @@ class BucketManager implements BucketManagerInterface
         );
     }
 
-    public function dropBucket(string $name, DropBucketOptions $options = null)
+    public function dropBucket(string $name, ?DropBucketOptions $options = null)
     {
         $exportedOptions = DropBucketOptions::export($options);
         $request = RequestFactory::makeRequest(
@@ -102,7 +102,7 @@ class BucketManager implements BucketManagerInterface
     /**
      * @throws BucketNotFoundException
      */
-    public function getBucket(string $name, GetBucketOptions $options = null): BucketSettings
+    public function getBucket(string $name, ?GetBucketOptions $options = null): BucketSettings
     {
         $exportedOptions = GetBucketOptions::export($options);
         $getAllBucketOptions = isset($exportedOptions['timeoutMilliseconds'])
@@ -119,7 +119,7 @@ class BucketManager implements BucketManagerInterface
     /**
      * @throws DecodingFailureException|InvalidArgumentException
      */
-    public function getAllBuckets(GetAllBucketsOptions $options = null): array
+    public function getAllBuckets(?GetAllBucketsOptions $options = null): array
     {
         $exportedOptions = GetAllBucketsOptions::export($options);
         $timeout = $this->client->timeoutHandler()->getTimeout(TimeoutHandler::MANAGEMENT, $exportedOptions);
@@ -141,7 +141,7 @@ class BucketManager implements BucketManagerInterface
     /**
      * @throws UnsupportedOperationException
      */
-    public function flush(string $name, FlushBucketOptions $options = null)
+    public function flush(string $name, ?FlushBucketOptions $options = null)
     {
         throw new UnsupportedOperationException("Flush is not available in CNG");
     }

--- a/Couchbase/Protostellar/Management/CollectionManager.php
+++ b/Couchbase/Protostellar/Management/CollectionManager.php
@@ -50,7 +50,7 @@ class CollectionManager implements CollectionManagerInterface
         $this->client = $client;
     }
 
-    public function getAllScopes(GetAllScopesOptions $options = null): array
+    public function getAllScopes(?GetAllScopesOptions $options = null): array
     {
         $exportedOptions = GetAllScopesOptions::export($options);
         $request = RequestFactory::makeRequest(
@@ -65,7 +65,7 @@ class CollectionManager implements CollectionManagerInterface
         return CollectionManagementResponseConverter::convertGetAllScopesResult($res);
     }
 
-    public function createScope(string $name, CreateScopeOptions $options = null)
+    public function createScope(string $name, ?CreateScopeOptions $options = null)
     {
         $exportedOptions = CreateScopeOptions::export($options);
         $request = RequestFactory::makeRequest(
@@ -79,7 +79,7 @@ class CollectionManager implements CollectionManagerInterface
         );
     }
 
-    public function dropScope(string $name, DropScopeOptions $options = null)
+    public function dropScope(string $name, ?DropScopeOptions $options = null)
     {
         $exportedOptions = DropScopeOptions::export($options);
         $request = RequestFactory::makeRequest(
@@ -151,7 +151,7 @@ class CollectionManager implements CollectionManagerInterface
     /**
      * @throws UnsupportedOperationException
      */
-    public function updateCollection(string $scopeName, string $collectionName, UpdateCollectionSettings $settings, UpdateCollectionOptions $options = null)
+    public function updateCollection(string $scopeName, string $collectionName, UpdateCollectionSettings $settings, ?UpdateCollectionOptions $options = null)
     {
         throw new UnsupportedOperationException("Update collection is not yet supported in CNG");
     }

--- a/Couchbase/Protostellar/Management/CollectionQueryIndexManager.php
+++ b/Couchbase/Protostellar/Management/CollectionQueryIndexManager.php
@@ -57,7 +57,7 @@ class CollectionQueryIndexManager implements CollectionQueryIndexManagerInterfac
      * @throws DecodingFailureException
      * @throws InvalidArgumentException
      */
-    public function getAllIndexes(GetAllQueryIndexesOptions $options = null): array
+    public function getAllIndexes(?GetAllQueryIndexesOptions $options = null): array
     {
         $exportedOptions = GetAllQueryIndexesOptions::export($options);
         $this->checkOptions($exportedOptions);
@@ -76,7 +76,7 @@ class CollectionQueryIndexManager implements CollectionQueryIndexManagerInterfac
     /**
      * @throws InvalidArgumentException
      */
-    public function createPrimaryIndex(CreateQueryPrimaryIndexOptions $options = null)
+    public function createPrimaryIndex(?CreateQueryPrimaryIndexOptions $options = null)
     {
         $exportedOptions = CreateQueryPrimaryIndexOptions::export($options);
         $this->checkOptions($exportedOptions);
@@ -94,7 +94,7 @@ class CollectionQueryIndexManager implements CollectionQueryIndexManagerInterfac
     /**
      * @throws InvalidArgumentException
      */
-    public function createIndex(string $indexName, array $fields, CreateQueryIndexOptions $options = null)
+    public function createIndex(string $indexName, array $fields, ?CreateQueryIndexOptions $options = null)
     {
         $exportedOptions = CreateQueryIndexOptions::export($options);
         $this->checkOptions($exportedOptions);
@@ -112,7 +112,7 @@ class CollectionQueryIndexManager implements CollectionQueryIndexManagerInterfac
     /**
      * @throws InvalidArgumentException
      */
-    public function dropIndex(string $indexName, DropQueryIndexOptions $options = null)
+    public function dropIndex(string $indexName, ?DropQueryIndexOptions $options = null)
     {
         $exportedOptions = DropQueryIndexOptions::export($options);
         $this->checkOptions($exportedOptions);
@@ -130,7 +130,7 @@ class CollectionQueryIndexManager implements CollectionQueryIndexManagerInterfac
     /**
      * @throws InvalidArgumentException
      */
-    public function dropPrimaryIndex(DropQueryPrimaryIndexOptions $options = null)
+    public function dropPrimaryIndex(?DropQueryPrimaryIndexOptions $options = null)
     {
         $exportedOptions = DropQueryPrimaryIndexOptions::export($options);
         $this->checkOptions($exportedOptions);
@@ -148,7 +148,7 @@ class CollectionQueryIndexManager implements CollectionQueryIndexManagerInterfac
     /**
      * @throws InvalidArgumentException
      */
-    public function buildDeferredIndexes(BuildQueryIndexesOptions $options = null)
+    public function buildDeferredIndexes(?BuildQueryIndexesOptions $options = null)
     {
         $exportedOptions = BuildQueryIndexesOptions::export($options);
         $this->checkOptions($exportedOptions);
@@ -167,7 +167,7 @@ class CollectionQueryIndexManager implements CollectionQueryIndexManagerInterfac
      * @throws UnambiguousTimeoutException
      * @throws InvalidArgumentException
      */
-    public function watchIndexes(array $indexNames, int $timeoutMilliseconds, WatchQueryIndexesOptions $options = null)
+    public function watchIndexes(array $indexNames, int $timeoutMilliseconds, ?WatchQueryIndexesOptions $options = null)
     {
         $exported = WatchQueryIndexesOptions::export($options);
         $this->checkOptions($exported);

--- a/Couchbase/Protostellar/Management/QueryIndexManager.php
+++ b/Couchbase/Protostellar/Management/QueryIndexManager.php
@@ -50,7 +50,7 @@ class QueryIndexManager implements QueryIndexManagerInterface
     /**
      * @throws DecodingFailureException
      */
-    public function getAllIndexes(string $bucketName, GetAllQueryIndexesOptions $options = null): array
+    public function getAllIndexes(string $bucketName, ?GetAllQueryIndexesOptions $options = null): array
     {
         $exportedOptions = GetAllQueryIndexesOptions::export($options);
         $request = RequestFactory::makeRequest(
@@ -65,7 +65,7 @@ class QueryIndexManager implements QueryIndexManagerInterface
         return QueryIndexManagementResponseConverter::convertGetAllIndexesResult($response);
     }
 
-    public function createPrimaryIndex(string $bucketName, CreateQueryPrimaryIndexOptions $options = null)
+    public function createPrimaryIndex(string $bucketName, ?CreateQueryPrimaryIndexOptions $options = null)
     {
         $exportedOptions = CreateQueryPrimaryIndexOptions::export($options);
         $request = RequestFactory::makeRequest(
@@ -79,7 +79,7 @@ class QueryIndexManager implements QueryIndexManagerInterface
         );
     }
 
-    public function createIndex(string $bucketName, string $indexName, array $fields, CreateQueryIndexOptions $options = null)
+    public function createIndex(string $bucketName, string $indexName, array $fields, ?CreateQueryIndexOptions $options = null)
     {
         $exportedOptions = CreateQueryIndexOptions::export($options);
         $request = RequestFactory::makeRequest(
@@ -93,7 +93,7 @@ class QueryIndexManager implements QueryIndexManagerInterface
         );
     }
 
-    public function dropIndex(string $bucketName, string $indexName, DropQueryIndexOptions $options = null)
+    public function dropIndex(string $bucketName, string $indexName, ?DropQueryIndexOptions $options = null)
     {
         $exportedOptions = DropQueryIndexOptions::export($options);
         $request = RequestFactory::makeRequest(
@@ -107,7 +107,7 @@ class QueryIndexManager implements QueryIndexManagerInterface
         );
     }
 
-    public function dropPrimaryIndex(string $bucketName, DropQueryPrimaryIndexOptions $options = null)
+    public function dropPrimaryIndex(string $bucketName, ?DropQueryPrimaryIndexOptions $options = null)
     {
         $exportedOptions = DropQueryPrimaryIndexOptions::export($options);
         $request = RequestFactory::makeRequest(
@@ -121,7 +121,7 @@ class QueryIndexManager implements QueryIndexManagerInterface
         );
     }
 
-    public function buildDeferredIndexes(string $bucketName, BuildQueryIndexesOptions $options = null)
+    public function buildDeferredIndexes(string $bucketName, ?BuildQueryIndexesOptions $options = null)
     {
         $exportedOptions = BuildQueryIndexesOptions::export($options);
         $request = RequestFactory::makeRequest(
@@ -139,7 +139,7 @@ class QueryIndexManager implements QueryIndexManagerInterface
      * @throws UnambiguousTimeoutException
      * @throws DecodingFailureException
      */
-    public function watchIndexes(string $bucketName, array $indexNames, int $timeoutMilliseconds, WatchQueryIndexesOptions $options = null)
+    public function watchIndexes(string $bucketName, array $indexNames, int $timeoutMilliseconds, ?WatchQueryIndexesOptions $options = null)
     {
         $exported = WatchQueryIndexesOptions::export($options);
         if (array_key_exists("watchPrimary", $exported) && $exported["watchPrimary"]) {

--- a/Couchbase/Protostellar/Management/SearchIndexManager.php
+++ b/Couchbase/Protostellar/Management/SearchIndexManager.php
@@ -53,7 +53,7 @@ class SearchIndexManager implements SearchIndexManagerInterface
     /**
      * @throws InvalidArgumentException
      */
-    public function getIndex(string $indexName, GetSearchIndexOptions $options = null): SearchIndex
+    public function getIndex(string $indexName, ?GetSearchIndexOptions $options = null): SearchIndex
     {
         $exportedOptions = GetSearchIndexOptions::export($options);
         $request = RequestFactory::makeRequest(
@@ -71,7 +71,7 @@ class SearchIndexManager implements SearchIndexManagerInterface
     /**
      * @throws InvalidArgumentException
      */
-    public function getAllIndexes(GetAllSearchIndexesOptions $options = null): array
+    public function getAllIndexes(?GetAllSearchIndexesOptions $options = null): array
     {
         $exportedOptions = GetAllSearchIndexesOptions::export($options);
         $request = RequestFactory::makeRequest(
@@ -86,7 +86,7 @@ class SearchIndexManager implements SearchIndexManagerInterface
         return SearchIndexManagementResponseConverter::convertGetAllIndexesResult($response);
     }
 
-    public function upsertIndex(SearchIndex $indexDefinition, UpsertSearchIndexOptions $options = null)
+    public function upsertIndex(SearchIndex $indexDefinition, ?UpsertSearchIndexOptions $options = null)
     {
         $exportedOptions = UpsertSearchIndexOptions::export($options);
         $exportedIndex = SearchIndex::export($indexDefinition);
@@ -113,7 +113,7 @@ class SearchIndexManager implements SearchIndexManagerInterface
         }
     }
 
-    public function dropIndex(string $name, DropSearchIndexOptions $options = null)
+    public function dropIndex(string $name, ?DropSearchIndexOptions $options = null)
     {
         $exportedOptions = DropSearchIndexOptions::export($options);
         $request = RequestFactory::makeRequest(
@@ -127,7 +127,7 @@ class SearchIndexManager implements SearchIndexManagerInterface
         );
     }
 
-    public function getIndexedDocumentsCount(string $indexName, GetIndexedSearchIndexOptions $options = null): int
+    public function getIndexedDocumentsCount(string $indexName, ?GetIndexedSearchIndexOptions $options = null): int
     {
         $exportedOptions = GetIndexedSearchIndexOptions::export($options);
         $request = RequestFactory::makeRequest(
@@ -141,7 +141,7 @@ class SearchIndexManager implements SearchIndexManagerInterface
         );
     }
 
-    public function pauseIngest(string $indexName, PauseIngestSearchIndexOptions $options = null)
+    public function pauseIngest(string $indexName, ?PauseIngestSearchIndexOptions $options = null)
     {
         $exportedOptions = PauseIngestSearchIndexOptions::export($options);
         $request = RequestFactory::makeRequest(
@@ -155,7 +155,7 @@ class SearchIndexManager implements SearchIndexManagerInterface
         );
     }
 
-    public function resumeIngest(string $indexName, ResumeIngestSearchIndexOptions $options = null)
+    public function resumeIngest(string $indexName, ?ResumeIngestSearchIndexOptions $options = null)
     {
         $exportedOptions = ResumeIngestSearchIndexOptions::export($options);
         $request = RequestFactory::makeRequest(
@@ -169,7 +169,7 @@ class SearchIndexManager implements SearchIndexManagerInterface
         );
     }
 
-    public function allowQuerying(string $indexName, AllowQueryingSearchIndexOptions $options = null)
+    public function allowQuerying(string $indexName, ?AllowQueryingSearchIndexOptions $options = null)
     {
         $exportedOptions = AllowQueryingSearchIndexOptions::export($options);
         $request = RequestFactory::makeRequest(
@@ -183,7 +183,7 @@ class SearchIndexManager implements SearchIndexManagerInterface
         );
     }
 
-    public function disallowQuerying(string $indexName, DisallowQueryingSearchIndexOptions $options = null)
+    public function disallowQuerying(string $indexName, ?DisallowQueryingSearchIndexOptions $options = null)
     {
         $exportedOptions = DisallowQueryingSearchIndexOptions::export($options);
         $request = RequestFactory::makeRequest(
@@ -197,7 +197,7 @@ class SearchIndexManager implements SearchIndexManagerInterface
         );
     }
 
-    public function freezePlan(string $indexName, FreezePlanSearchIndexOptions $options = null)
+    public function freezePlan(string $indexName, ?FreezePlanSearchIndexOptions $options = null)
     {
         $exportedOptions = FreezePlanSearchIndexOptions::export($options);
         $request = RequestFactory::makeRequest(
@@ -211,7 +211,7 @@ class SearchIndexManager implements SearchIndexManagerInterface
         );
     }
 
-    public function unfreezePlan(string $indexName, UnfreezePlanSearchIndexOptions $options = null)
+    public function unfreezePlan(string $indexName, ?UnfreezePlanSearchIndexOptions $options = null)
     {
         $exportedOptions = UnfreezePlanSearchIndexOptions::export($options);
         $request = RequestFactory::makeRequest(
@@ -225,7 +225,7 @@ class SearchIndexManager implements SearchIndexManagerInterface
         );
     }
 
-    public function analyzeDocument(string $indexName, $document, AnalyzeDocumentOptions $options = null): array
+    public function analyzeDocument(string $indexName, $document, ?AnalyzeDocumentOptions $options = null): array
     {
         $exportedOptions = AnalyzeDocumentOptions::export($options);
         $request = RequestFactory::makeRequest(

--- a/Couchbase/Protostellar/ProtocolException.php
+++ b/Couchbase/Protostellar/ProtocolException.php
@@ -45,7 +45,7 @@ class ProtocolException extends Exception
 {
     private ?object $grpcStatus = null;
 
-    public function __construct($message, $grpcStatus = null, Throwable $previous = null)
+    public function __construct($message, $grpcStatus = null, ?Throwable $previous = null)
     {
         $code = 0;
         if ($grpcStatus) {

--- a/Couchbase/Protostellar/Retries/BestEffortRetryStrategy.php
+++ b/Couchbase/Protostellar/Retries/BestEffortRetryStrategy.php
@@ -26,7 +26,7 @@ class BestEffortRetryStrategy implements RetryStrategy
 {
     private BackoffCalculator $calculator;
 
-    public function __construct(BackoffCalculator $calculator = null)
+    public function __construct(?BackoffCalculator $calculator = null)
     {
         if (is_null($calculator)) {
             $this->calculator = new ExponentialBackoff();

--- a/Couchbase/Protostellar/Scope.php
+++ b/Couchbase/Protostellar/Scope.php
@@ -62,7 +62,7 @@ class Scope implements ScopeInterface
     /**
      * @throws InvalidArgumentException
      */
-    public function query(string $statement, QueryOptions $options = null): QueryResult
+    public function query(string $statement, ?QueryOptions $options = null): QueryResult
     {
         $exportedOptions = QueryOptions::export($options);
         $exportedOptions["bucketName"] = $this->bucketName;
@@ -80,7 +80,7 @@ class Scope implements ScopeInterface
         return new QueryResult($finalArray, QueryOptions::getTranscoder($options));
     }
 
-    public function analyticsQuery(string $statement, AnalyticsOptions $options = null): AnalyticsResult
+    public function analyticsQuery(string $statement, ?AnalyticsOptions $options = null): AnalyticsResult
     {
         $exportedOptions = AnalyticsOptions::export($options, $this->name, $this->bucketName);
         $request = RequestFactory::makeRequest(

--- a/Couchbase/QueryOptions.php
+++ b/Couchbase/QueryOptions.php
@@ -414,7 +414,7 @@ class QueryOptions
         return $options->transcoder;
     }
 
-    public static function export(?QueryOptions $options, string $scopeName = null, string $bucketName = null): array
+    public static function export(?QueryOptions $options, ?string $scopeName = null, ?string $bucketName = null): array
     {
         $defaultQueryContext = null;
         if ($scopeName != null && $bucketName != null) {

--- a/Couchbase/RangeScan.php
+++ b/Couchbase/RangeScan.php
@@ -34,7 +34,7 @@ class RangeScan implements ScanType
      *
      * @since 4.1.6
      */
-    public function __construct(ScanTerm $from = null, ScanTerm $to = null)
+    public function __construct(?ScanTerm $from = null, ?ScanTerm $to = null)
     {
         $this->from = $from;
         $this->to = $to;
@@ -49,7 +49,7 @@ class RangeScan implements ScanType
      * @return RangeScan
      * @since 4.1.6
      */
-    public static function build(ScanTerm $from = null, ScanTerm $to = null): RangeScan
+    public static function build(?ScanTerm $from = null, ?ScanTerm $to = null): RangeScan
     {
         return new RangeScan($from, $to);
     }

--- a/Couchbase/RequestTracer.php
+++ b/Couchbase/RequestTracer.php
@@ -31,5 +31,5 @@ interface RequestTracer
      * @param string $name The name of the span.
      * @param string|null $parent The parent of the span, if one exists.
      */
-    public function requestSpan(string $name, RequestSpan $parent = null);
+    public function requestSpan(string $name, ?RequestSpan $parent = null);
 }

--- a/Couchbase/SamplingScan.php
+++ b/Couchbase/SamplingScan.php
@@ -37,7 +37,7 @@ class SamplingScan implements ScanType
      * @throws InvalidArgumentException
      * @since 4.1.6
      */
-    public function __construct(int $limit, int $seed = null)
+    public function __construct(int $limit, ?int $seed = null)
     {
         if ($limit < 1) {
             throw new InvalidArgumentException("The limit must be positive");
@@ -56,7 +56,7 @@ class SamplingScan implements ScanType
      * @throws InvalidArgumentException
      * @since 4.1.6
      */
-    public static function build(int $limit, int $seed = null): SamplingScan
+    public static function build(int $limit, ?int $seed = null): SamplingScan
     {
         return new SamplingScan($limit, $seed);
     }

--- a/Couchbase/ScanTerm.php
+++ b/Couchbase/ScanTerm.php
@@ -31,7 +31,7 @@ class ScanTerm
      *
      * @since 4.1.6
      */
-    public function __construct(string $term, bool $exclusive = null)
+    public function __construct(string $term, ?bool $exclusive = null)
     {
         $this->term = $term;
         $this->exclusive = $exclusive;
@@ -46,7 +46,7 @@ class ScanTerm
      * @return ScanTerm
      * @since 4.1.6
      */
-    public static function build(string $term, bool $exclusive = null): ScanTerm
+    public static function build(string $term, ?bool $exclusive = null): ScanTerm
     {
         return new ScanTerm($term, $exclusive);
     }

--- a/Couchbase/Scope.php
+++ b/Couchbase/Scope.php
@@ -89,7 +89,7 @@ class Scope implements ScopeInterface
      * @throws CouchbaseException
      * @since 4.0.0
      */
-    public function query(string $statement, QueryOptions $options = null): QueryResult
+    public function query(string $statement, ?QueryOptions $options = null): QueryResult
     {
         $result = Extension\query($this->core, $statement, QueryOptions::export($options, $this->name, $this->bucketName));
 
@@ -107,7 +107,7 @@ class Scope implements ScopeInterface
      * @throws CouchbaseException
      * @since 4.0.0
      */
-    public function analyticsQuery(string $statement, AnalyticsOptions $options = null): AnalyticsResult
+    public function analyticsQuery(string $statement, ?AnalyticsOptions $options = null): AnalyticsResult
     {
         $result = Extension\analyticsQuery($this->core, $statement, AnalyticsOptions::export($options, $this->name, $this->bucketName));
 
@@ -127,7 +127,7 @@ class Scope implements ScopeInterface
      * @throws InvalidArgumentException
      * @since 4.1.7
      */
-    public function search(string $indexName, SearchRequest $request, SearchOptions $options = null): SearchResult
+    public function search(string $indexName, SearchRequest $request, ?SearchOptions $options = null): SearchResult
     {
         $exportedRequest = SearchRequest::export($request);
         $exportedOptions = SearchOptions::export($options);

--- a/Couchbase/ScopeInterface.php
+++ b/Couchbase/ScopeInterface.php
@@ -31,11 +31,11 @@ interface ScopeInterface
 
     public function collection(string $name): CollectionInterface;
 
-    public function query(string $statement, QueryOptions $options = null): QueryResult;
+    public function query(string $statement, ?QueryOptions $options = null): QueryResult;
 
-    public function search(string $indexName, SearchRequest $request, SearchOptions $options = null): SearchResult;
+    public function search(string $indexName, SearchRequest $request, ?SearchOptions $options = null): SearchResult;
 
-    public function analyticsQuery(string $statement, AnalyticsOptions $options = null): AnalyticsResult;
+    public function analyticsQuery(string $statement, ?AnalyticsOptions $options = null): AnalyticsResult;
 
     public function searchIndexes(): ScopeSearchIndexManagerInterface;
 }

--- a/Couchbase/SearchOptions.php
+++ b/Couchbase/SearchOptions.php
@@ -220,7 +220,7 @@ class SearchOptions implements JsonSerializable
      * @see \SearchHighlightMode::ANSI
      * @see \SearchHighlightMode::SIMPLE
      */
-    public function highlight(string $style = null, array $fields = null): SearchOptions
+    public function highlight(?string $style = null, ?array $fields = null): SearchOptions
     {
         $this->highlight['style'] = $style;
         $this->highlight['fields'] = $fields;

--- a/Couchbase/ThresholdLoggingTracer.php
+++ b/Couchbase/ThresholdLoggingTracer.php
@@ -34,7 +34,7 @@ class ThresholdLoggingTracer implements RequestTracer
     /**
      * @throws UnsupportedOperationException
      */
-    public function requestSpan(string $name, RequestSpan $parent = null)
+    public function requestSpan(string $name, ?RequestSpan $parent = null)
     {
         throw new UnsupportedOperationException();
     }

--- a/Couchbase/TransactionQueryOptions.php
+++ b/Couchbase/TransactionQueryOptions.php
@@ -362,7 +362,7 @@ class TransactionQueryOptions
         return $options->transcoder;
     }
 
-    public static function export(?TransactionQueryOptions $options, string $scopeName = null, string $bucketName = null): array
+    public static function export(?TransactionQueryOptions $options, ?string $scopeName = null, ?string $bucketName = null): array
     {
         if ($options == null) {
             return [

--- a/Couchbase/VectorSearch.php
+++ b/Couchbase/VectorSearch.php
@@ -38,7 +38,7 @@ class VectorSearch implements JsonSerializable
      *
      * @UNCOMMITTED: This API may change in the future.
      */
-    public function __construct(array $vectorQueries, VectorSearchOptions $options = null)
+    public function __construct(array $vectorQueries, ?VectorSearchOptions $options = null)
     {
         if (empty($vectorQueries)) {
             throw new InvalidArgumentException("At least one vector query must be specified");
@@ -58,7 +58,7 @@ class VectorSearch implements JsonSerializable
      *
      * @UNCOMMITTED: This API may change in the future.
      */
-    public static function build(array $vectorQueries, VectorSearchOptions $options = null): VectorSearch
+    public static function build(array $vectorQueries, ?VectorSearchOptions $options = null): VectorSearch
     {
         return new VectorSearch($vectorQueries, $options);
     }

--- a/tests/CollectionManagerTest.php
+++ b/tests/CollectionManagerTest.php
@@ -409,7 +409,7 @@ class CollectionManagerTest extends Helpers\CouchbaseTestCase
     /**
      * @throws ScopeNotFoundException
      */
-    private function getScope(string $scopeName, CollectionManager $manager = null): ScopeSpec
+    private function getScope(string $scopeName, ?CollectionManager $manager = null): ScopeSpec
     {
         if (is_null($manager)) {
             $manager = $this->manager;


### PR DESCRIPTION
Otherwise PHP 8.4 will emit deprecation warning

I used the following regexps to fix it:

* when first argument is nullable
  ```sed
  s@(\([^?,]\+ \$[^,]\+ = null\)@(?\1@g
  ```
* when any other argument is nullable
  ```sed
  s@, \([^?,]\+ \$[^,]\+ = null\)@, ?\1@g
  ```