### PR TITLE
PCBC-1011: SearchQuery link in API doc is broken

### DIFF
--- a/Couchbase/SearchQuery.php
+++ b/Couchbase/SearchQuery.php
@@ -25,7 +25,7 @@ namespace Couchbase;
  *
  * Represents full text search query
  *
- * @see https://developer.couchbase.com/documentation/server/4.6/sdk/php/full-text-searching-with-sdk.html
+ * @see https://docs.couchbase.com/php-sdk/current/howtos/full-text-searching-with-sdk.html
  *   Searching from the SDK
  */
 interface SearchQuery


### PR DESCRIPTION
Changes:
- Updated SearchQuery API link to current