### PR TITLE
PCBC-975 : Fix expiry with upsertMulti

### DIFF
--- a/src/wrapper/connection_handle.cxx
+++ b/src/wrapper/connection_handle.cxx
@@ -2096,6 +2096,9 @@ connection_handle::document_upsert_multi(zval* return_value,
   if (auto e = cb_set_durability(opts, options); e.ec) {
     return e;
   }
+  if (auto e = cb_set_expiry(opts, options); e.ec) {
+    return e;
+  }
   if (auto e = cb_set_preserve_expiry(opts, options); e.ec) {
     return e;
   }


### PR DESCRIPTION
This should fix https://jira.issues.couchbase.com/browse/PCBC-975. It seems like the call to set the expiry was just missing for no obvious reason.