### PR TITLE
PCBC-993: Support Binary Objects in Transactions

### DIFF
--- a/Couchbase/TransactionGetOptions.php
+++ b/Couchbase/TransactionGetOptions.php
@@ -1,0 +1,76 @@
+<?php
+
+/**
+ * Copyright 2014-Present Couchbase, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+declare(strict_types=1);
+
+namespace Couchbase;
+
+class TransactionGetOptions
+{
+    private Transcoder $transcoder;
+
+
+    /**
+     * @since 4.3.0
+     */
+    public function __construct()
+    {
+        $this->transcoder = JsonTranscoder::getInstance();
+    }
+
+    /**
+     * Static helper to keep code more readable
+     *
+     * @return TransactionGetOptions
+     * @since 4.3.0
+     */
+    public static function build(): TransactionGetOptions
+    {
+        return new TransactionGetOptions();
+    }
+
+    /**
+     * Associate custom transcoder with the request.
+     *
+     * @param Transcoder $transcoder
+     *
+     * @return TransactionGetOptions
+     * @since 4.3.0
+     */
+    public function transcoder(Transcoder $transcoder): TransactionGetOptions
+    {
+        $this->transcoder = $transcoder;
+        return $this;
+    }
+
+    /**
+     * Returns associated transcoder.
+     *
+     * @param TransactionGetOptions|null $options
+     *
+     * @return Transcoder
+     * @since 4.3.0
+     */
+    public static function getTranscoder(?TransactionGetOptions $options): Transcoder
+    {
+        if ($options == null) {
+            return JsonTranscoder::getInstance();
+        }
+        return $options->transcoder;
+    }
+}

--- a/Couchbase/TransactionGetResult.php
+++ b/Couchbase/TransactionGetResult.php
@@ -28,6 +28,7 @@ class TransactionGetResult extends Result
     private string $scopeName;
     private string $collectionName;
     private string $value;
+    private int $flags;
     private string $cas;
     private ?array $links = null;
     private ?array $metadata = null;
@@ -45,6 +46,7 @@ class TransactionGetResult extends Result
         $this->collectionName = $response["collectionName"];
         $this->id = $response["id"];
         $this->value = $response["value"];
+        $this->flags = $response["flags"];
         $this->cas = $response["cas"];
         if (array_key_exists("links", $response)) {
             $this->links = $response["links"];
@@ -62,7 +64,7 @@ class TransactionGetResult extends Result
      */
     public function content()
     {
-        return $this->transcoder->decode($this->value, 0);
+        return $this->transcoder->decode($this->value, $this->flags);
     }
 
     /**

--- a/Couchbase/TransactionInsertOptions.php
+++ b/Couchbase/TransactionInsertOptions.php
@@ -1,0 +1,92 @@
+<?php
+
+/**
+ * Copyright 2014-Present Couchbase, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+declare(strict_types=1);
+
+namespace Couchbase;
+
+class TransactionInsertOptions
+{
+    private Transcoder $transcoder;
+
+    /**
+     * @since 4.3.0
+     */
+    public function __construct()
+    {
+        $this->transcoder = JsonTranscoder::getInstance();
+    }
+
+    /**
+     * Static helper to keep code more readable
+     *
+     * @return TransactionInsertOptions
+     * @since 4.3.0
+     */
+    public static function build(): TransactionInsertOptions
+    {
+        return new TransactionInsertOptions();
+    }
+
+    /**
+     * Associate custom transcoder with the request.
+     *
+     * @param Transcoder $transcoder
+     *
+     * @return TransactionInsertOptions
+     * @since 4.3.0
+     */
+    public function transcoder(Transcoder $transcoder): TransactionInsertOptions
+    {
+        $this->transcoder = $transcoder;
+        return $this;
+    }
+
+    /**
+     * Delegates encoding of the document to associated transcoder
+     *
+     * @param TransactionInsertOptions|null $options
+     * @param                    $document
+     *
+     * @return array
+     * @since 4.3.0
+     */
+    public static function encodeDocument(?TransactionInsertOptions $options, $document): array
+    {
+        if ($options == null) {
+            return JsonTranscoder::getInstance()->encode($document);
+        }
+        return $options->transcoder->encode($document);
+    }
+
+    /**
+     * Returns associated transcoder.
+     *
+     * @param TransactionInsertOptions|null $options
+     *
+     * @return Transcoder
+     * @since 4.3.0
+     */
+    public static function getTranscoder(?TransactionInsertOptions $options): Transcoder
+    {
+        if ($options == null) {
+            return JsonTranscoder::getInstance();
+        }
+        return $options->transcoder;
+    }
+}

--- a/Couchbase/TransactionReplaceOptions.php
+++ b/Couchbase/TransactionReplaceOptions.php
@@ -1,0 +1,92 @@
+<?php
+
+/**
+ * Copyright 2014-Present Couchbase, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+declare(strict_types=1);
+
+namespace Couchbase;
+
+class TransactionReplaceOptions
+{
+    private Transcoder $transcoder;
+
+    /**
+     * @since 4.3.0
+     */
+    public function __construct()
+    {
+        $this->transcoder = JsonTranscoder::getInstance();
+    }
+
+    /**
+     * Static helper to keep code more readable
+     *
+     * @return TransactionReplaceOptions
+     * @since 4.3.0
+     */
+    public static function build(): TransactionReplaceOptions
+    {
+        return new TransactionReplaceOptions();
+    }
+
+    /**
+     * Associate custom transcoder with the request.
+     *
+     * @param Transcoder $transcoder
+     *
+     * @return TransactionReplaceOptions
+     * @since 4.3.0
+     */
+    public function transcoder(Transcoder $transcoder): TransactionReplaceOptions
+    {
+        $this->transcoder = $transcoder;
+        return $this;
+    }
+
+    /**
+     * Delegates encoding of the document to associated transcoder
+     *
+     * @param TransactionReplaceOptions|null $options
+     * @param                    $document
+     *
+     * @return array
+     * @since 4.3.0
+     */
+    public static function encodeDocument(?TransactionReplaceOptions $options, $document): array
+    {
+        if ($options == null) {
+            return JsonTranscoder::getInstance()->encode($document);
+        }
+        return $options->transcoder->encode($document);
+    }
+
+    /**
+     * Returns associated transcoder.
+     *
+     * @param TransactionReplaceOptions|null $options
+     *
+     * @return Transcoder
+     * @since 4.3.0
+     */
+    public static function getTranscoder(?TransactionReplaceOptions $options): Transcoder
+    {
+        if ($options == null) {
+            return JsonTranscoder::getInstance();
+        }
+        return $options->transcoder;
+    }
+}

--- a/src/php_couchbase.cxx
+++ b/src/php_couchbase.cxx
@@ -2677,14 +2677,16 @@ PHP_FUNCTION(transactionInsert)
   zend_string* collection = nullptr;
   zend_string* id = nullptr;
   zend_string* value = nullptr;
+  zend_long flags = 0;
 
-  ZEND_PARSE_PARAMETERS_START(6, 6)
+  ZEND_PARSE_PARAMETERS_START(7, 7)
   Z_PARAM_RESOURCE(transaction)
   Z_PARAM_STR(bucket)
   Z_PARAM_STR(scope)
   Z_PARAM_STR(collection)
   Z_PARAM_STR(id)
   Z_PARAM_STR(value)
+  Z_PARAM_LONG(flags)
   ZEND_PARSE_PARAMETERS_END();
 
   logger_flusher guard;
@@ -2693,7 +2695,7 @@ PHP_FUNCTION(transactionInsert)
   if (context == nullptr) {
     RETURN_THROWS();
   }
-  if (auto e = context->insert(return_value, bucket, scope, collection, id, value); e.ec) {
+  if (auto e = context->insert(return_value, bucket, scope, collection, id, value, flags); e.ec) {
     couchbase_throw_exception(e);
     RETURN_THROWS();
   }
@@ -2704,11 +2706,14 @@ PHP_FUNCTION(transactionReplace)
   zval* transaction = nullptr;
   zval* document = nullptr;
   zend_string* value = nullptr;
+  zend_long flags = 0;
 
-  ZEND_PARSE_PARAMETERS_START(3, 3)
+
+  ZEND_PARSE_PARAMETERS_START(4, 4)
   Z_PARAM_RESOURCE(transaction)
   Z_PARAM_ARRAY(document)
   Z_PARAM_STR(value)
+  Z_PARAM_LONG(flags)
   ZEND_PARSE_PARAMETERS_END();
 
   logger_flusher guard;
@@ -2717,7 +2722,7 @@ PHP_FUNCTION(transactionReplace)
   if (context == nullptr) {
     RETURN_THROWS();
   }
-  if (auto e = context->replace(return_value, document, value); e.ec) {
+  if (auto e = context->replace(return_value, document, value, flags); e.ec) {
     couchbase_throw_exception(e);
     RETURN_THROWS();
   }
@@ -4391,19 +4396,21 @@ ZEND_ARG_TYPE_INFO(0, collectionName, IS_STRING, 0)
 ZEND_ARG_TYPE_INFO(0, id, IS_STRING, 0)
 ZEND_END_ARG_INFO()
 
-ZEND_BEGIN_ARG_INFO_EX(ai_CouchbaseExtension_transactionInsert, 0, 0, 6)
+ZEND_BEGIN_ARG_INFO_EX(ai_CouchbaseExtension_transactionInsert, 0, 0, 7)
 ZEND_ARG_INFO(0, transactions)
 ZEND_ARG_TYPE_INFO(0, bucketName, IS_STRING, 0)
 ZEND_ARG_TYPE_INFO(0, scopeName, IS_STRING, 0)
 ZEND_ARG_TYPE_INFO(0, collectionName, IS_STRING, 0)
 ZEND_ARG_TYPE_INFO(0, id, IS_STRING, 0)
 ZEND_ARG_TYPE_INFO(0, value, IS_STRING, 0)
+ZEND_ARG_TYPE_INFO(0, flags, IS_LONG, 0)
 ZEND_END_ARG_INFO()
 
-ZEND_BEGIN_ARG_INFO_EX(ai_CouchbaseExtension_transactionReplace, 0, 0, 3)
+ZEND_BEGIN_ARG_INFO_EX(ai_CouchbaseExtension_transactionReplace, 0, 0, 4)
 ZEND_ARG_INFO(0, transactions)
 ZEND_ARG_TYPE_INFO(0, document, IS_ARRAY, 0)
 ZEND_ARG_TYPE_INFO(0, value, IS_STRING, 0)
+ZEND_ARG_TYPE_INFO(0, flags, IS_LONG, 0)
 ZEND_END_ARG_INFO()
 
 ZEND_BEGIN_ARG_INFO_EX(ai_CouchbaseExtension_transactionRemove, 0, 0, 2)

--- a/src/wrapper/transaction_context_resource.hxx
+++ b/src/wrapper/transaction_context_resource.hxx
@@ -68,10 +68,11 @@ public:
                          const zend_string* scope,
                          const zend_string* collection,
                          const zend_string* id,
-                         const zend_string* value);
+                         const zend_string* value,
+                         zend_long flags);
 
   COUCHBASE_API
-  core_error_info replace(zval* return_value, const zval* document, const zend_string* value);
+  core_error_info replace(zval* return_value, const zval* document, const zend_string* value, zend_long flags);
   COUCHBASE_API
   core_error_info remove(const zval* document);
 

--- a/tests/Helpers/ServerVersion.php
+++ b/tests/Helpers/ServerVersion.php
@@ -259,6 +259,12 @@ class ServerVersion
         return $this->isCheshireCat() || $this->isNeo();
     }
 
+    public function supportsBinaryTransactions(): bool
+    {
+        // 7.6.2 or above
+        return $this->major > 7 || ($this->major == 7 && ($this->minor > 6 || ($this->minor == 6 && $this->micro >= 2)));
+    }
+
     public function supportsRangeScan(): bool
     {
         return $this->is75() || $this->is76();


### PR DESCRIPTION
Changes:
- Added Options w/ Transcoder for Transactions Insert, Replace, Get, and GetReplica
- Updated core to use specified transcoder flags