### PR TITLE
PCBC-1023: Add numVBuckets to BucketSettings

### DIFF
--- a/Couchbase/Management/BucketSettings.php
+++ b/Couchbase/Management/BucketSettings.php
@@ -37,6 +37,7 @@ class BucketSettings
     private ?bool $historyRetentionCollectionDefault = null;
     private ?int $historyRetentionBytes = null;
     private ?int $historyRetentionDuration = null;
+    private ?int $numVBuckets = null;
 
     /**
      * @param string $name the name of the bucket
@@ -258,6 +259,17 @@ class BucketSettings
     public function historyRetentionDuration(): ?int
     {
         return $this->historyRetentionDuration;
+    }
+
+    /**
+     * Gets the number of vBuckets in this bucket
+     *
+     * @return int|null
+     * @since 4.3.0
+     */
+    public function numVBuckets(): ?int
+    {
+        return $this->numVBuckets;
     }
 
     /**
@@ -541,7 +553,7 @@ class BucketSettings
     }
 
     /**
-     * Sets teh maximum number of seconds to be covered by the change history that is written to disk for all collections
+     * Sets the maximum number of seconds to be covered by the change history that is written to disk for all collections
      * in this bucket
      *
      * @param int $historyRetentionDuration duration in seconds
@@ -553,6 +565,21 @@ class BucketSettings
     public function setHistoryRetentionDuration(int $historyRetentionDuration): BucketSettings
     {
         $this->historyRetentionDuration = $historyRetentionDuration;
+        return $this;
+    }
+
+    /**
+     * Sets the number of vBuckets this bucket
+     *
+     * @param int $numVBuckets number of vBuckets
+     *
+     * @return BucketSettings
+     *
+     * @since 4.3.0
+     */
+    public function setNumVBuckets(int $numVBuckets): BucketSettings
+    {
+        $this->numVBuckets = $numVBuckets;
         return $this;
     }
 
@@ -578,6 +605,7 @@ class BucketSettings
             'historyRetentionCollectionDefault' => $bucket->historyRetentionCollectionDefault,
             'historyRetentionBytes' => $bucket->historyRetentionBytes,
             'historyRetentionDuration' => $bucket->historyRetentionDuration,
+            'numVBuckets' => $bucket->numVBuckets,
         ];
     }
 
@@ -629,6 +657,9 @@ class BucketSettings
         }
         if (array_key_exists('historyRetentionDuration', $bucket)) {
             $settings->setHistoryRetentionDuration($bucket['historyRetentionDuration']);
+        }
+        if (array_key_exists('numVBuckets', $bucket)) {
+            $settings->setNumVBuckets($bucket['numVBuckets']);
         }
 
         return $settings;

--- a/src/wrapper/connection_handle.cxx
+++ b/src/wrapper/connection_handle.cxx
@@ -3630,6 +3630,12 @@ zval_to_bucket_settings(const zval* bucket_settings)
     return { e, {} };
   }
 
+  if (auto e = cb_assign_integer(
+        bucket.num_vbuckets, bucket_settings, "numVBuckets");
+      e.ec) {
+    return { e, {} };
+  }
+
   return { {}, bucket };
 }
 } // namespace
@@ -3819,6 +3825,11 @@ cb_bucket_settings_to_zval(
   if (bucket_settings.history_retention_duration.has_value()) {
     add_assoc_long(
       return_value, "historyRetentionDuration", bucket_settings.history_retention_duration.value());
+  }
+
+  if (bucket_settings.num_vbuckets.has_value()) {
+    add_assoc_long(
+      return_value, "numVBuckets", bucket_settings.num_vbuckets.value());
   }
 
   return {};

--- a/tests/Helpers/ServerVersion.php
+++ b/tests/Helpers/ServerVersion.php
@@ -306,6 +306,11 @@ class ServerVersion
         return $this->major > 7 || ($this->major == 7 && ($this->minor > 6 || ($this->minor == 6 && $this->micro >= 2)));
     }
 
+    public function supportsMagma128(): bool
+    {
+        return $this->major >= 8;
+    }
+
     /**
      * @return int
      */


### PR DESCRIPTION
Motivation
----------
The server is adding support for creating Magma buckets with 128 vBuckets. We are adding a numVBuckets parameter to bucket_settings to allow configuring the number of vbuckets.

Changes
-------
Add numVBuckets to BucketSettings