### PR TITLE
PCBC-1027: Operational SDK prevent connection to Analytics 2.0 Cluster

### DIFF
--- a/src/php_couchbase.cxx
+++ b/src/php_couchbase.cxx
@@ -238,6 +238,12 @@ PHP_FUNCTION(loadExceptionAliases)
   RETURN_NULL();
 }
 
+PHP_FUNCTION(allowEnterpriseAnalytics)
+{
+  couchbase::php::allow_enterprise_analytics();
+  RETURN_NULL();
+}
+
 PHP_FUNCTION(createConnection)
 {
   zend_string* connection_hash = nullptr;
@@ -3833,6 +3839,9 @@ ZEND_END_ARG_INFO()
 ZEND_BEGIN_ARG_INFO_EX(ai_CouchbaseExtension_loadExceptionAliases, 0, 0, 0)
 ZEND_END_ARG_INFO()
 
+ZEND_BEGIN_ARG_INFO_EX(ai_CouchbaseExtension_allowEnterpriseAnalytics, 0, 0, 0)
+ZEND_END_ARG_INFO()
+
 ZEND_BEGIN_ARG_INFO_EX(ai_CouchbaseExtension_clusterVersion, 0, 0, 2)
 ZEND_ARG_INFO(0, connection)
 ZEND_ARG_TYPE_INFO(0, bucketName, IS_STRING, 0)
@@ -4729,6 +4738,7 @@ ZEND_END_ARG_INFO()
 static zend_function_entry couchbase_functions[] = {
         ZEND_NS_FE("Couchbase\\Extension" COUCHBASE_NAMESPACE_ABI_SUFFIX, notifyFork, ai_CouchbaseExtension_notifyFork)
         ZEND_NS_FE("Couchbase\\Extension" COUCHBASE_NAMESPACE_ABI_SUFFIX, loadExceptionAliases, ai_CouchbaseExtension_loadExceptionAliases)
+        ZEND_NS_FE("Couchbase\\Extension" COUCHBASE_NAMESPACE_ABI_SUFFIX, allowEnterpriseAnalytics, ai_CouchbaseExtension_allowEnterpriseAnalytics)
         ZEND_NS_FE("Couchbase\\Extension" COUCHBASE_NAMESPACE_ABI_SUFFIX, version, ai_CouchbaseExtension_version)
         ZEND_NS_FE("Couchbase\\Extension" COUCHBASE_NAMESPACE_ABI_SUFFIX, clusterVersion, ai_CouchbaseExtension_clusterVersion)
         ZEND_NS_FE("Couchbase\\Extension" COUCHBASE_NAMESPACE_ABI_SUFFIX, replicasConfiguredForBucket, ai_CouchbaseExtension_replicasConfiguredForBucket)

--- a/src/wrapper/common.cxx
+++ b/src/wrapper/common.cxx
@@ -18,8 +18,8 @@
 #include "wrapper.hxx"
 
 #include "common.hxx"
+#include "core/operations/document_analytics.hxx"
 #include "core/utils/json.hxx"
-
 #include <couchbase/error_codes.hxx>
 
 #include <spdlog/fmt/bundled/core.h>
@@ -1067,4 +1067,12 @@ create_exception(zval* return_value, const core_error_info& error_info)
   couchbase_update_property(couchbase_exception_ce, return_value, "context", &context);
   Z_DELREF(context);
 }
+
+COUCHBASE_API
+void
+allow_enterprise_analytics()
+{
+  core::operations::analytics_request::allow_enterprise_analytics = true;
+}
+
 } // namespace couchbase::php

--- a/src/wrapper/common.hxx
+++ b/src/wrapper/common.hxx
@@ -71,4 +71,8 @@ map_error_to_exception(const core_error_info& info);
 
 COUCHBASE_API void
 create_exception(zval* return_value, const couchbase::php::core_error_info& error_info);
+
+COUCHBASE_API void
+allow_enterprise_analytics();
+
 } // namespace couchbase::php


### PR DESCRIPTION
Changes:
- Update core to pick up Analytics 2.0 connection prevention